### PR TITLE
[codex] add shared clone worktree workspace manager

### DIFF
--- a/Symphony.slnx
+++ b/Symphony.slnx
@@ -6,6 +6,7 @@
     <Project Path="src/Symphony.Infrastructure.Persistence.Sqlite/Symphony.Infrastructure.Persistence.Sqlite.csproj" />
     <Project Path="src/Symphony.Infrastructure.Tracker.GitHub/Symphony.Infrastructure.Tracker.GitHub.csproj" />
     <Project Path="src/Symphony.Infrastructure.Workflows/Symphony.Infrastructure.Workflows.csproj" />
+    <Project Path="src/Symphony.Infrastructure.Workspaces/Symphony.Infrastructure.Workspaces.csproj" />
   </Folder>
   <Folder Name="/tests/">
     <Project Path="tests/Symphony.Core.Tests/Symphony.Core.Tests.csproj" />

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -16,6 +16,12 @@ polling:
   interval_ms: 600000
 agent:
   max_concurrent_agents: 5
+workspace:
+  root: ./workspaces
+  shared_clone_path: ./workspaces/repo
+  worktrees_root: ./workspaces/worktrees
+  base_branch: main
+  remote_url: null
 ---
 
 You are working on a GitHub issue for this repository.

--- a/src/Symphony.Core/Abstractions/IWorkspaceManager.cs
+++ b/src/Symphony.Core/Abstractions/IWorkspaceManager.cs
@@ -1,0 +1,10 @@
+using Symphony.Core.Models;
+
+namespace Symphony.Core.Abstractions;
+
+public interface IWorkspaceManager
+{
+    Task<WorkspacePreparationResult> PrepareIssueWorkspaceAsync(
+        WorkspacePreparationRequest request,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Symphony.Core/Models/WorkspacePreparationRequest.cs
+++ b/src/Symphony.Core/Models/WorkspacePreparationRequest.cs
@@ -1,0 +1,11 @@
+namespace Symphony.Core.Models;
+
+public sealed record WorkspacePreparationRequest(
+    string IssueId,
+    string IssueIdentifier,
+    string? SuggestedBranchName,
+    string WorkspaceRoot,
+    string SharedClonePath,
+    string WorktreesRoot,
+    string BaseBranch,
+    string RemoteRepositoryUrl);

--- a/src/Symphony.Core/Models/WorkspacePreparationResult.cs
+++ b/src/Symphony.Core/Models/WorkspacePreparationResult.cs
@@ -1,0 +1,6 @@
+namespace Symphony.Core.Models;
+
+public sealed record WorkspacePreparationResult(
+    string WorkspacePath,
+    string BranchName,
+    bool CreatedNow);

--- a/src/Symphony.Host/Program.cs
+++ b/src/Symphony.Host/Program.cs
@@ -6,6 +6,7 @@ using Symphony.Host.Workers;
 using Symphony.Infrastructure.Persistence.Sqlite;
 using Symphony.Infrastructure.Persistence.Sqlite.Storage;
 using Symphony.Infrastructure.Tracker.GitHub;
+using Symphony.Infrastructure.Workspaces;
 using Symphony.Infrastructure.Workflows;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -34,6 +35,7 @@ builder.Services
 builder.Services.AddSymphonySqlitePersistence(builder.Configuration);
 builder.Services.AddSymphonyWorkflowServices(builder.Configuration);
 builder.Services.AddSymphonyGitHubTrackerClient();
+builder.Services.AddSymphonyWorkspaceServices();
 builder.Services.AddScoped<OrchestrationTickService>();
 
 builder.Services
@@ -86,6 +88,14 @@ app.MapGet("/api/v1/runtime", async (
             agent = new
             {
                 definition.Runtime.Agent.MaxConcurrentAgents
+            },
+            workspace = new
+            {
+                definition.Runtime.Workspace.Root,
+                definition.Runtime.Workspace.SharedClonePath,
+                definition.Runtime.Workspace.WorktreesRoot,
+                definition.Runtime.Workspace.BaseBranch,
+                definition.Runtime.Workspace.RemoteUrl
             }
         };
     }

--- a/src/Symphony.Host/Services/OrchestrationTickService.cs
+++ b/src/Symphony.Host/Services/OrchestrationTickService.cs
@@ -11,6 +11,7 @@ public sealed class OrchestrationTickService(
     IWorkflowDefinitionProvider workflowDefinitionProvider,
     IGitHubTrackerClient trackerClient,
     IOrchestrationCoordinationStore coordinationStore,
+    IWorkspaceManager workspaceManager,
     IOptions<OrchestrationOptions> orchestrationOptions,
     ILogger<OrchestrationTickService> logger)
 {
@@ -79,18 +80,43 @@ public sealed class OrchestrationTickService(
 
             try
             {
-                // Dispatch hook placeholder until agent execution is wired.
+                var remoteUrl = ResolveRemoteUrl(
+                    workflowDefinition.Runtime.Workspace.RemoteUrl,
+                    workflowDefinition.Runtime.Tracker.Owner,
+                    workflowDefinition.Runtime.Tracker.Repo);
+
+                var workspace = await workspaceManager.PrepareIssueWorkspaceAsync(
+                    new WorkspacePreparationRequest(
+                        IssueId: issue.Id,
+                        IssueIdentifier: issue.Identifier,
+                        SuggestedBranchName: issue.BranchName,
+                        WorkspaceRoot: workflowDefinition.Runtime.Workspace.Root,
+                        SharedClonePath: workflowDefinition.Runtime.Workspace.SharedClonePath,
+                        WorktreesRoot: workflowDefinition.Runtime.Workspace.WorktreesRoot,
+                        BaseBranch: workflowDefinition.Runtime.Workspace.BaseBranch,
+                        RemoteRepositoryUrl: remoteUrl),
+                    cancellationToken);
+
                 logger.LogInformation(
-                    "Claimed issue {IssueIdentifier} ({IssueId}) for dispatch placeholder.",
+                    "Prepared workspace {WorkspacePath} for issue {IssueIdentifier} ({IssueId}) on branch {BranchName}.",
+                    workspace.WorkspacePath,
                     issue.Identifier,
-                    issue.Id);
-            }
-            finally
-            {
+                    issue.Id,
+                    workspace.BranchName);
+
                 await coordinationStore.ReleaseIssueClaimAsync(
                     issue.Id,
                     instanceId,
-                    "released",
+                    "workspace_prepared",
+                    cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Failed preparing workspace for issue {IssueIdentifier} ({IssueId}).", issue.Identifier, issue.Id);
+                await coordinationStore.ReleaseIssueClaimAsync(
+                    issue.Id,
+                    instanceId,
+                    "workspace_failed",
                     cancellationToken);
             }
         }
@@ -127,5 +153,15 @@ public sealed class OrchestrationTickService(
         }
 
         return Environment.GetEnvironmentVariable(variableName);
+    }
+
+    private static string ResolveRemoteUrl(string? configuredRemoteUrl, string owner, string repo)
+    {
+        if (!string.IsNullOrWhiteSpace(configuredRemoteUrl))
+        {
+            return configuredRemoteUrl;
+        }
+
+        return $"https://github.com/{owner}/{repo}.git";
     }
 }

--- a/src/Symphony.Host/Symphony.Host.csproj
+++ b/src/Symphony.Host/Symphony.Host.csproj
@@ -6,6 +6,7 @@
     <ProjectReference Include="..\Symphony.Infrastructure.Tracker.GitHub\Symphony.Infrastructure.Tracker.GitHub.csproj" />
     <ProjectReference Include="..\Symphony.Infrastructure.Agent.Codex\Symphony.Infrastructure.Agent.Codex.csproj" />
     <ProjectReference Include="..\Symphony.Infrastructure.Workflows\Symphony.Infrastructure.Workflows.csproj" />
+    <ProjectReference Include="..\Symphony.Infrastructure.Workspaces\Symphony.Infrastructure.Workspaces.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Symphony.Infrastructure.Workflows/Models/WorkflowRuntimeSettings.cs
+++ b/src/Symphony.Infrastructure.Workflows/Models/WorkflowRuntimeSettings.cs
@@ -3,7 +3,8 @@ namespace Symphony.Infrastructure.Workflows.Models;
 public sealed record WorkflowRuntimeSettings(
     WorkflowTrackerSettings Tracker,
     WorkflowPollingSettings Polling,
-    WorkflowAgentSettings Agent);
+    WorkflowAgentSettings Agent,
+    WorkflowWorkspaceSettings Workspace);
 
 public sealed record WorkflowTrackerSettings(
     string Kind,
@@ -19,3 +20,10 @@ public sealed record WorkflowTrackerSettings(
 public sealed record WorkflowPollingSettings(int IntervalMs);
 
 public sealed record WorkflowAgentSettings(int MaxConcurrentAgents);
+
+public sealed record WorkflowWorkspaceSettings(
+    string Root,
+    string SharedClonePath,
+    string WorktreesRoot,
+    string BaseBranch,
+    string? RemoteUrl);

--- a/src/Symphony.Infrastructure.Workflows/WorkflowLoader.cs
+++ b/src/Symphony.Infrastructure.Workflows/WorkflowLoader.cs
@@ -160,6 +160,18 @@ public sealed class WorkflowLoader
             throw new WorkflowLoadException("invalid_max_concurrent_agents", "agent.max_concurrent_agents must be > 0.");
         }
 
+        var workspaceMap = GetOptionalMap(config, "workspace");
+        var workspaceRoot = GetOptionalStringFromOptionalMap(workspaceMap, "root") ?? "./workspaces";
+        var sharedClonePath = GetOptionalStringFromOptionalMap(workspaceMap, "shared_clone_path") ?? "./workspaces/repo";
+        var worktreesRoot = GetOptionalStringFromOptionalMap(workspaceMap, "worktrees_root") ?? "./workspaces/worktrees";
+        var baseBranch = GetOptionalStringFromOptionalMap(workspaceMap, "base_branch") ?? "main";
+        var remoteUrl = GetOptionalStringFromOptionalMap(workspaceMap, "remote_url");
+
+        if (string.IsNullOrWhiteSpace(baseBranch))
+        {
+            throw new WorkflowLoadException("invalid_workspace_base_branch", "workspace.base_branch must be non-empty.");
+        }
+
         return new WorkflowRuntimeSettings(
             new WorkflowTrackerSettings(
                 kind.ToLowerInvariant(),
@@ -172,7 +184,13 @@ public sealed class WorkflowLoader
                 activeStates,
                 terminalStates),
             new WorkflowPollingSettings(intervalMs),
-            new WorkflowAgentSettings(maxConcurrentAgents));
+            new WorkflowAgentSettings(maxConcurrentAgents),
+            new WorkflowWorkspaceSettings(
+                workspaceRoot,
+                sharedClonePath,
+                worktreesRoot,
+                baseBranch,
+                remoteUrl));
     }
 
     private static Dictionary<string, object?>? GetOptionalMap(IReadOnlyDictionary<string, object?> source, string key)
@@ -213,6 +231,16 @@ public sealed class WorkflowLoader
             string str => str.Trim(),
             _ => throw new WorkflowLoadException("workflow_parse_error", $"'{key}' must be a string.")
         };
+    }
+
+    private static string? GetOptionalStringFromOptionalMap(Dictionary<string, object?>? source, string key)
+    {
+        if (source is null)
+        {
+            return null;
+        }
+
+        return GetOptionalString(source, key);
     }
 
     private static string? GetOptionalStringOrNumber(Dictionary<string, object?> source, string key)

--- a/src/Symphony.Infrastructure.Workspaces/GitWorktreeWorkspaceManager.cs
+++ b/src/Symphony.Infrastructure.Workspaces/GitWorktreeWorkspaceManager.cs
@@ -1,0 +1,205 @@
+using System.Diagnostics;
+using System.Text;
+using System.Text.RegularExpressions;
+using Microsoft.Extensions.Logging;
+using Symphony.Core.Abstractions;
+using Symphony.Core.Models;
+
+namespace Symphony.Infrastructure.Workspaces;
+
+public sealed partial class GitWorktreeWorkspaceManager(
+    ILogger<GitWorktreeWorkspaceManager> logger) : IWorkspaceManager
+{
+    public async Task<WorkspacePreparationResult> PrepareIssueWorkspaceAsync(
+        WorkspacePreparationRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(request.WorkspaceRoot))
+        {
+            throw new InvalidOperationException("workspace.root must be configured.");
+        }
+
+        if (string.IsNullOrWhiteSpace(request.RemoteRepositoryUrl))
+        {
+            throw new InvalidOperationException("workspace.remote_url could not be resolved.");
+        }
+
+        var rootPath = GetAbsolutePath(request.WorkspaceRoot);
+        var sharedClonePath = GetAbsolutePath(request.SharedClonePath);
+        var worktreesRootPath = GetAbsolutePath(request.WorktreesRoot);
+        var issueKey = SanitizeIssueIdentifier(request.IssueIdentifier);
+        var worktreePath = Path.Combine(worktreesRootPath, issueKey);
+        var branchName = string.IsNullOrWhiteSpace(request.SuggestedBranchName)
+            ? $"symphony/{issueKey}"
+            : request.SuggestedBranchName.Trim();
+
+        EnsurePathIsWithinRoot(rootPath, sharedClonePath);
+        EnsurePathIsWithinRoot(rootPath, worktreesRootPath);
+        EnsurePathIsWithinRoot(worktreesRootPath, worktreePath);
+
+        Directory.CreateDirectory(rootPath);
+        Directory.CreateDirectory(worktreesRootPath);
+
+        await EnsureSharedCloneAsync(sharedClonePath, request.RemoteRepositoryUrl, cancellationToken);
+        await EnsureLatestFromOriginAsync(sharedClonePath, request.BaseBranch, cancellationToken);
+
+        if (Directory.Exists(worktreePath))
+        {
+            logger.LogInformation(
+                "Reusing existing workspace {WorkspacePath} for issue {IssueIdentifier}.",
+                worktreePath,
+                request.IssueIdentifier);
+
+            return new WorkspacePreparationResult(worktreePath, branchName, CreatedNow: false);
+        }
+
+        var hasLocalBranch = await HasLocalBranchAsync(sharedClonePath, branchName, cancellationToken);
+        if (hasLocalBranch)
+        {
+            await RunGitAsync(sharedClonePath, ["worktree", "add", worktreePath, branchName], cancellationToken);
+        }
+        else
+        {
+            await RunGitAsync(
+                sharedClonePath,
+                ["worktree", "add", "-b", branchName, worktreePath, $"origin/{request.BaseBranch}"],
+                cancellationToken);
+        }
+
+        logger.LogInformation(
+            "Prepared workspace {WorkspacePath} (branch {BranchName}) for issue {IssueIdentifier}.",
+            worktreePath,
+            branchName,
+            request.IssueIdentifier);
+
+        return new WorkspacePreparationResult(worktreePath, branchName, CreatedNow: true);
+    }
+
+    private static string GetAbsolutePath(string path) =>
+        Path.GetFullPath(path);
+
+    private static void EnsurePathIsWithinRoot(string rootPath, string candidatePath)
+    {
+        var root = Path.GetFullPath(rootPath).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        var candidate = Path.GetFullPath(candidatePath);
+        var rootWithSeparator = root + Path.DirectorySeparatorChar;
+        if (!candidate.StartsWith(rootWithSeparator, StringComparison.OrdinalIgnoreCase) &&
+            !candidate.Equals(root, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException($"Path '{candidatePath}' must be within root '{rootPath}'.");
+        }
+    }
+
+    private static string SanitizeIssueIdentifier(string issueIdentifier)
+    {
+        var input = string.IsNullOrWhiteSpace(issueIdentifier) ? "issue" : issueIdentifier.Trim();
+        var sanitized = IssueIdentifierRegex().Replace(input, "-").Trim('-');
+        return string.IsNullOrWhiteSpace(sanitized) ? "issue" : sanitized.ToLowerInvariant();
+    }
+
+    private async Task EnsureSharedCloneAsync(
+        string sharedClonePath,
+        string remoteRepositoryUrl,
+        CancellationToken cancellationToken)
+    {
+        var gitDirectoryPath = Path.Combine(sharedClonePath, ".git");
+        if (Directory.Exists(gitDirectoryPath))
+        {
+            await RunGitAsync(sharedClonePath, ["remote", "set-url", "origin", remoteRepositoryUrl], cancellationToken);
+            return;
+        }
+
+        var parentDirectory = Path.GetDirectoryName(sharedClonePath);
+        if (!string.IsNullOrWhiteSpace(parentDirectory))
+        {
+            Directory.CreateDirectory(parentDirectory);
+        }
+
+        await RunGitAsync(
+            workingDirectory: null,
+            ["clone", "--no-checkout", remoteRepositoryUrl, sharedClonePath],
+            cancellationToken);
+    }
+
+    private async Task EnsureLatestFromOriginAsync(string sharedClonePath, string baseBranch, CancellationToken cancellationToken)
+    {
+        await RunGitAsync(sharedClonePath, ["fetch", "origin", "--prune"], cancellationToken);
+        await RunGitAsync(sharedClonePath, ["fetch", "origin", baseBranch], cancellationToken);
+    }
+
+    private async Task<bool> HasLocalBranchAsync(string sharedClonePath, string branchName, CancellationToken cancellationToken)
+    {
+        var result = await RunGitAsync(
+            sharedClonePath,
+            ["show-ref", "--verify", $"refs/heads/{branchName}"],
+            cancellationToken,
+            throwOnNonZeroExitCode: false);
+
+        return result.ExitCode == 0;
+    }
+
+    private async Task<GitResult> RunGitAsync(
+        string? workingDirectory,
+        IReadOnlyList<string> arguments,
+        CancellationToken cancellationToken,
+        bool throwOnNonZeroExitCode = true)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "git",
+            WorkingDirectory = workingDirectory ?? Environment.CurrentDirectory,
+            RedirectStandardError = true,
+            RedirectStandardOutput = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+
+        foreach (var arg in arguments)
+        {
+            startInfo.ArgumentList.Add(arg);
+        }
+
+        using var process = new Process { StartInfo = startInfo };
+        var stdout = new StringBuilder();
+        var stderr = new StringBuilder();
+
+        process.OutputDataReceived += (_, args) =>
+        {
+            if (args.Data is not null)
+            {
+                stdout.AppendLine(args.Data);
+            }
+        };
+
+        process.ErrorDataReceived += (_, args) =>
+        {
+            if (args.Data is not null)
+            {
+                stderr.AppendLine(args.Data);
+            }
+        };
+
+        if (!process.Start())
+        {
+            throw new InvalidOperationException("Failed to start git process.");
+        }
+
+        process.BeginOutputReadLine();
+        process.BeginErrorReadLine();
+        await process.WaitForExitAsync(cancellationToken);
+
+        var result = new GitResult(process.ExitCode, stdout.ToString(), stderr.ToString());
+        if (throwOnNonZeroExitCode && result.ExitCode != 0)
+        {
+            throw new InvalidOperationException(
+                $"Git command failed (exit {result.ExitCode}): git {string.Join(' ', arguments)}{Environment.NewLine}{result.Stderr}");
+        }
+
+        return result;
+    }
+
+    private sealed record GitResult(int ExitCode, string Stdout, string Stderr);
+
+    [GeneratedRegex(@"[^a-zA-Z0-9._-]+")]
+    private static partial Regex IssueIdentifierRegex();
+}

--- a/src/Symphony.Infrastructure.Workspaces/ServiceCollectionExtensions.cs
+++ b/src/Symphony.Infrastructure.Workspaces/ServiceCollectionExtensions.cs
@@ -1,0 +1,13 @@
+using Microsoft.Extensions.DependencyInjection;
+using Symphony.Core.Abstractions;
+
+namespace Symphony.Infrastructure.Workspaces;
+
+public static class ServiceCollectionExtensions
+{
+    public static IServiceCollection AddSymphonyWorkspaceServices(this IServiceCollection services)
+    {
+        services.AddSingleton<IWorkspaceManager, GitWorktreeWorkspaceManager>();
+        return services;
+    }
+}

--- a/src/Symphony.Infrastructure.Workspaces/Symphony.Infrastructure.Workspaces.csproj
+++ b/src/Symphony.Infrastructure.Workspaces/Symphony.Infrastructure.Workspaces.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\Symphony.Core\Symphony.Core.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/tests/Symphony.Integration.Tests/Symphony.Integration.Tests.csproj
+++ b/tests/Symphony.Integration.Tests/Symphony.Integration.Tests.csproj
@@ -24,6 +24,7 @@
     <ProjectReference Include="..\..\src\Symphony.Infrastructure.Persistence.Sqlite\Symphony.Infrastructure.Persistence.Sqlite.csproj" />
     <ProjectReference Include="..\..\src\Symphony.Infrastructure.Tracker.GitHub\Symphony.Infrastructure.Tracker.GitHub.csproj" />
     <ProjectReference Include="..\..\src\Symphony.Infrastructure.Workflows\Symphony.Infrastructure.Workflows.csproj" />
+    <ProjectReference Include="..\..\src\Symphony.Infrastructure.Workspaces\Symphony.Infrastructure.Workspaces.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Symphony.Integration.Tests/WorkflowLoaderTests.cs
+++ b/tests/Symphony.Integration.Tests/WorkflowLoaderTests.cs
@@ -40,6 +40,10 @@ public sealed class WorkflowLoaderTests
         Assert.Equal("symphony", definition.Runtime.Tracker.Repo);
         Assert.Equal(120000, definition.Runtime.Polling.IntervalMs);
         Assert.Equal(3, definition.Runtime.Agent.MaxConcurrentAgents);
+        Assert.Equal("./workspaces", definition.Runtime.Workspace.Root);
+        Assert.Equal("./workspaces/repo", definition.Runtime.Workspace.SharedClonePath);
+        Assert.Equal("./workspaces/worktrees", definition.Runtime.Workspace.WorktreesRoot);
+        Assert.Equal("main", definition.Runtime.Workspace.BaseBranch);
         Assert.Equal("Test prompt body.", definition.PromptTemplate);
 
         File.Delete(workflowPath);

--- a/tests/Symphony.Integration.Tests/WorkspaceManagerTests.cs
+++ b/tests/Symphony.Integration.Tests/WorkspaceManagerTests.cs
@@ -1,0 +1,93 @@
+using System.Diagnostics;
+using Microsoft.Extensions.Logging.Abstractions;
+using Symphony.Core.Models;
+using Symphony.Infrastructure.Workspaces;
+
+namespace Symphony.Integration.Tests;
+
+public sealed class WorkspaceManagerTests
+{
+    [Fact]
+    public async Task PrepareIssueWorkspaceAsync_ShouldCreateSharedCloneAndWorktree()
+    {
+        var tempRoot = Path.Combine(Path.GetTempPath(), $"symphony-ws-{Guid.NewGuid():N}");
+        var remoteBare = Path.Combine(tempRoot, "remote.git");
+        var seedClone = Path.Combine(tempRoot, "seed");
+        var workspaceRoot = Path.Combine(tempRoot, "workspaces");
+        var sharedClonePath = Path.Combine(workspaceRoot, "repo");
+        var worktreesRoot = Path.Combine(workspaceRoot, "worktrees");
+
+        Directory.CreateDirectory(tempRoot);
+
+        await RunGitAsync(tempRoot, ["init", "--bare", remoteBare]);
+        await RunGitAsync(tempRoot, ["clone", remoteBare, seedClone]);
+        await RunGitAsync(seedClone, ["config", "user.name", "symfony-tests"]);
+        await RunGitAsync(seedClone, ["config", "user.email", "symphony-tests@example.com"]);
+        await File.WriteAllTextAsync(Path.Combine(seedClone, "README.md"), "seed");
+        await RunGitAsync(seedClone, ["add", "README.md"]);
+        await RunGitAsync(seedClone, ["commit", "-m", "seed"]);
+        await RunGitAsync(seedClone, ["branch", "-M", "main"]);
+        await RunGitAsync(seedClone, ["push", "-u", "origin", "main"]);
+
+        var manager = new GitWorktreeWorkspaceManager(NullLogger<GitWorktreeWorkspaceManager>.Instance);
+        var request = new WorkspacePreparationRequest(
+            IssueId: "I1",
+            IssueIdentifier: "#101",
+            SuggestedBranchName: null,
+            WorkspaceRoot: workspaceRoot,
+            SharedClonePath: sharedClonePath,
+            WorktreesRoot: worktreesRoot,
+            BaseBranch: "main",
+            RemoteRepositoryUrl: remoteBare);
+
+        var first = await manager.PrepareIssueWorkspaceAsync(request);
+        Assert.True(first.CreatedNow);
+        Assert.True(Directory.Exists(sharedClonePath));
+        Assert.True(Directory.Exists(first.WorkspacePath));
+        Assert.Equal("symphony/101", first.BranchName);
+
+        var currentBranch = await RunGitAsync(first.WorkspacePath, ["rev-parse", "--abbrev-ref", "HEAD"]);
+        Assert.Equal("symphony/101", currentBranch.Stdout.Trim());
+
+        var second = await manager.PrepareIssueWorkspaceAsync(request);
+        Assert.False(second.CreatedNow);
+    }
+
+    private static async Task<GitCommandResult> RunGitAsync(string workingDirectory, IReadOnlyList<string> args)
+    {
+        var info = new ProcessStartInfo
+        {
+            FileName = "git",
+            WorkingDirectory = workingDirectory,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+
+        foreach (var arg in args)
+        {
+            info.ArgumentList.Add(arg);
+        }
+
+        using var process = new Process { StartInfo = info };
+        if (!process.Start())
+        {
+            throw new InvalidOperationException("Failed to start git process.");
+        }
+
+        var stdout = await process.StandardOutput.ReadToEndAsync();
+        var stderr = await process.StandardError.ReadToEndAsync();
+        await process.WaitForExitAsync();
+
+        if (process.ExitCode != 0)
+        {
+            throw new InvalidOperationException(
+                $"Git failed (exit {process.ExitCode}) with args '{string.Join(' ', args)}'{Environment.NewLine}{stderr}");
+        }
+
+        return new GitCommandResult(stdout, stderr);
+    }
+
+    private sealed record GitCommandResult(string Stdout, string Stderr);
+}


### PR DESCRIPTION
## Summary
This PR implements the shared clone + worktree workspace strategy and wires it into orchestration dispatch preparation.

## Problem
The orchestrator could fetch and claim issues, but had no real workspace preparation path aligned with the chosen architecture (shared repository clone with per-issue worktrees). Without this, issue dispatch could not safely materialize a deterministic working directory and branch for agent execution.

## Root Cause
Workspace concerns were not yet modeled as a first-class service or configuration surface in the workflow runtime. The orchestration tick had no workspace manager dependency and therefore no place to enforce path safety, repository sync, and per-issue branch/worktree creation.

## What Changed
- Added workspace abstractions in core:
  - `IWorkspaceManager`
  - `WorkspacePreparationRequest`
  - `WorkspacePreparationResult`
- Added new infrastructure project: `Symphony.Infrastructure.Workspaces`.
- Implemented `GitWorktreeWorkspaceManager` with:
  - root/path containment enforcement
  - shared clone initialization and origin sync
  - per-issue worktree creation and branch selection
  - branch/workspace sanitization behavior for issue identifiers
- Added DI extension and wired workspace services into host startup.
- Extended workflow runtime model + parser to support `workspace` settings:
  - `root`
  - `shared_clone_path`
  - `worktrees_root`
  - `base_branch`
  - `remote_url`
- Updated `WORKFLOW.md` to include explicit workspace defaults.
- Integrated workspace preparation into `OrchestrationTickService` before releasing claims.
- Expanded runtime endpoint payload to include workspace settings loaded from the active workflow.
- Added integration tests:
  - workflow parser workspace defaults
  - real git-based workspace manager test validating shared clone + worktree creation/reuse

## User Impact
Symphony now prepares concrete per-issue workspaces using the selected worktree model, enabling deterministic workspace allocation as a prerequisite for agent execution.

## Validation
- `dotnet build Symphony.slnx -c Debug`
- `dotnet test Symphony.slnx -c Debug --no-build`

All checks pass.