### PR TITLE
[codex] Add GitHub issue state refresh and cursor guard

### DIFF
--- a/src/Symphony.Core/Models/IssueStateSnapshot.cs
+++ b/src/Symphony.Core/Models/IssueStateSnapshot.cs
@@ -1,0 +1,5 @@
+namespace Symphony.Core.Models;
+
+public sealed record IssueStateSnapshot(
+    string Id,
+    string State);

--- a/src/Symphony.Infrastructure.Tracker.GitHub/GitHubTrackerClient.cs
+++ b/src/Symphony.Infrastructure.Tracker.GitHub/GitHubTrackerClient.cs
@@ -8,7 +8,7 @@ namespace Symphony.Infrastructure.Tracker.GitHub;
 
 public sealed partial class GitHubTrackerClient(HttpClient httpClient) : IGitHubTrackerClient
 {
-    private const string GraphQlQuery = """
+    private const string GraphQlIssuesQuery = """
         query($owner: String!, $repo: String!, $states: [IssueState!], $labels: [String!], $first: Int!, $after: String) {
           repository(owner: $owner, name: $repo) {
             issues(states: $states, labels: $labels, first: $first, after: $after, orderBy: { field: CREATED_AT, direction: ASC }) {
@@ -50,6 +50,23 @@ public sealed partial class GitHubTrackerClient(HttpClient httpClient) : IGitHub
         }
         """;
 
+    private const string GraphQlIssueStatesByIdsQuery = """
+        query($ids: [ID!]!) {
+          nodes(ids: $ids) {
+            ... on Issue {
+              id
+              state
+              repository {
+                name
+                owner {
+                  login
+                }
+              }
+            }
+          }
+        }
+        """;
+
     public async Task<IReadOnlyList<NormalizedIssue>> FetchCandidateIssuesAsync(
         TrackerQuery query,
         CancellationToken cancellationToken = default)
@@ -73,6 +90,108 @@ public sealed partial class GitHubTrackerClient(HttpClient httpClient) : IGitHub
             cancellationToken);
     }
 
+    public async Task<IReadOnlyList<IssueStateSnapshot>> FetchIssueStatesByIdsAsync(
+        TrackerQuery query,
+        IReadOnlyList<string> issueIds,
+        CancellationToken cancellationToken = default)
+    {
+        if (issueIds.Count == 0)
+        {
+            return [];
+        }
+
+        var endpoint = string.IsNullOrWhiteSpace(query.Endpoint) ? "https://api.github.com/graphql" : query.Endpoint;
+        var orderedIds = issueIds
+            .Where(static id => !string.IsNullOrWhiteSpace(id))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        var statesById = new Dictionary<string, IssueStateSnapshot>(StringComparer.OrdinalIgnoreCase);
+        foreach (var issueIdBatch in orderedIds.Chunk(100))
+        {
+            using var request = new HttpRequestMessage(HttpMethod.Post, endpoint);
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", query.ApiKey);
+            request.Headers.UserAgent.Add(new ProductInfoHeaderValue("Symphony", "1.0"));
+            request.Content = JsonContent.Create(new
+            {
+                query = GraphQlIssueStatesByIdsQuery,
+                variables = new
+                {
+                    ids = issueIdBatch
+                }
+            });
+
+            using var response = await httpClient.SendAsync(request, cancellationToken);
+            if (!response.IsSuccessStatusCode)
+            {
+                throw new InvalidOperationException($"github_api_status: {(int)response.StatusCode}");
+            }
+
+            await using var contentStream = await response.Content.ReadAsStreamAsync(cancellationToken);
+            using var document = await JsonDocument.ParseAsync(contentStream, cancellationToken: cancellationToken);
+
+            if (document.RootElement.TryGetProperty("errors", out var errorsElement) &&
+                errorsElement.ValueKind == JsonValueKind.Array &&
+                errorsElement.GetArrayLength() > 0)
+            {
+                throw new InvalidOperationException("github_graphql_errors");
+            }
+
+            if (!document.RootElement.TryGetProperty("data", out var dataElement) ||
+                !dataElement.TryGetProperty("nodes", out var nodesElement) ||
+                nodesElement.ValueKind != JsonValueKind.Array)
+            {
+                throw new InvalidOperationException("github_unknown_payload");
+            }
+
+            foreach (var issueNode in nodesElement.EnumerateArray())
+            {
+                if (issueNode.ValueKind != JsonValueKind.Object)
+                {
+                    continue;
+                }
+
+                if (!issueNode.TryGetProperty("repository", out var repositoryNode) ||
+                    repositoryNode.ValueKind != JsonValueKind.Object)
+                {
+                    continue;
+                }
+
+                var owner = repositoryNode.TryGetProperty("owner", out var ownerNode)
+                    ? GetOptionalString(ownerNode, "login")
+                    : null;
+                var repo = GetOptionalString(repositoryNode, "name");
+
+                if (!string.Equals(owner, query.Owner, StringComparison.OrdinalIgnoreCase) ||
+                    !string.Equals(repo, query.Repo, StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                var issueId = GetOptionalString(issueNode, "id");
+                if (string.IsNullOrWhiteSpace(issueId))
+                {
+                    continue;
+                }
+
+                var issueState = GetOptionalString(issueNode, "state") ?? "OPEN";
+                var normalizedState = issueState.Equals("CLOSED", StringComparison.OrdinalIgnoreCase) ? "Closed" : "Open";
+                statesById[issueId] = new IssueStateSnapshot(issueId, normalizedState);
+            }
+        }
+
+        var result = new List<IssueStateSnapshot>(statesById.Count);
+        foreach (var issueId in orderedIds)
+        {
+            if (statesById.TryGetValue(issueId, out var state))
+            {
+                result.Add(state);
+            }
+        }
+
+        return result;
+    }
+
     private async Task<IReadOnlyList<NormalizedIssue>> FetchIssuesInternalAsync(
         TrackerQuery query,
         IReadOnlyList<string> states,
@@ -93,7 +212,7 @@ public sealed partial class GitHubTrackerClient(HttpClient httpClient) : IGitHub
             request.Headers.UserAgent.Add(new ProductInfoHeaderValue("Symphony", "1.0"));
             request.Content = JsonContent.Create(new
             {
-                query = GraphQlQuery,
+                query = GraphQlIssuesQuery,
                 variables = new
                 {
                     owner = query.Owner,
@@ -150,9 +269,22 @@ public sealed partial class GitHubTrackerClient(HttpClient httpClient) : IGitHub
 
             var pageInfo = issuesElement.GetProperty("pageInfo");
             hasNextPage = pageInfo.GetProperty("hasNextPage").GetBoolean();
-            cursor = hasNextPage && pageInfo.TryGetProperty("endCursor", out var endCursor)
-                ? endCursor.GetString()
-                : null;
+            if (!hasNextPage)
+            {
+                cursor = null;
+                continue;
+            }
+
+            if (!pageInfo.TryGetProperty("endCursor", out var endCursor))
+            {
+                throw new InvalidOperationException("github_missing_end_cursor");
+            }
+
+            cursor = endCursor.GetString();
+            if (string.IsNullOrWhiteSpace(cursor))
+            {
+                throw new InvalidOperationException("github_missing_end_cursor");
+            }
         }
 
         return candidateIssues;

--- a/src/Symphony.Infrastructure.Tracker.GitHub/IGitHubTrackerClient.cs
+++ b/src/Symphony.Infrastructure.Tracker.GitHub/IGitHubTrackerClient.cs
@@ -12,4 +12,9 @@ public interface IGitHubTrackerClient
         TrackerQuery query,
         IReadOnlyList<string> states,
         CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<IssueStateSnapshot>> FetchIssueStatesByIdsAsync(
+        TrackerQuery query,
+        IReadOnlyList<string> issueIds,
+        CancellationToken cancellationToken = default);
 }

--- a/tests/Symphony.Integration.Tests/GitHubTrackerClientTests.cs
+++ b/tests/Symphony.Integration.Tests/GitHubTrackerClientTests.cs
@@ -160,6 +160,111 @@ public sealed class GitHubTrackerClientTests
         Assert.Equal("Closed", issue.State);
     }
 
+    [Fact]
+    public async Task FetchCandidateIssuesAsync_ShouldFailWhenNextPageCursorMissing()
+    {
+        const string payload = """
+            {
+              "data": {
+                "repository": {
+                  "issues": {
+                    "pageInfo": {
+                      "hasNextPage": true,
+                      "endCursor": null
+                    },
+                    "nodes": []
+                  }
+                }
+              }
+            }
+            """;
+
+        using var httpClient = new HttpClient(new StaticJsonHandler(payload))
+        {
+            BaseAddress = new Uri("https://api.github.com/graphql")
+        };
+
+        var client = new GitHubTrackerClient(httpClient);
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            client.FetchCandidateIssuesAsync(new TrackerQuery(
+                Endpoint: "https://api.github.com/graphql",
+                ApiKey: "token",
+                Owner: "released",
+                Repo: "symphony",
+                ActiveStates: ["Open"],
+                Labels: [],
+                Milestone: null)));
+
+        Assert.Contains("github_missing_end_cursor", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task FetchIssueStatesByIdsAsync_ShouldReturnOnlyScopedIssueStates()
+    {
+        const string payload = """
+            {
+              "data": {
+                "nodes": [
+                  {
+                    "id": "I_100",
+                    "state": "OPEN",
+                    "repository": {
+                      "name": "symphony",
+                      "owner": { "login": "released" }
+                    }
+                  },
+                  {
+                    "id": "I_200",
+                    "state": "CLOSED",
+                    "repository": {
+                      "name": "symphony",
+                      "owner": { "login": "released" }
+                    }
+                  },
+                  {
+                    "id": "I_999",
+                    "state": "CLOSED",
+                    "repository": {
+                      "name": "other",
+                      "owner": { "login": "released" }
+                    }
+                  }
+                ]
+              }
+            }
+            """;
+
+        using var httpClient = new HttpClient(new StaticJsonHandler(payload))
+        {
+            BaseAddress = new Uri("https://api.github.com/graphql")
+        };
+
+        var client = new GitHubTrackerClient(httpClient);
+        var states = await client.FetchIssueStatesByIdsAsync(
+            new TrackerQuery(
+                Endpoint: "https://api.github.com/graphql",
+                ApiKey: "token",
+                Owner: "released",
+                Repo: "symphony",
+                ActiveStates: ["Open"],
+                Labels: [],
+                Milestone: null),
+            issueIds: ["I_200", "I_100", "I_999", "I_404"]);
+
+        Assert.Collection(
+            states,
+            state =>
+            {
+                Assert.Equal("I_200", state.Id);
+                Assert.Equal("Closed", state.State);
+            },
+            state =>
+            {
+                Assert.Equal("I_100", state.Id);
+                Assert.Equal("Open", state.State);
+            });
+    }
+
     private sealed class StaticJsonHandler(string json) : HttpMessageHandler
     {
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)

--- a/tests/Symphony.Integration.Tests/OrchestrationTickServiceTests.cs
+++ b/tests/Symphony.Integration.Tests/OrchestrationTickServiceTests.cs
@@ -475,6 +475,14 @@ public sealed class OrchestrationTickServiceTests
 
             return Task.FromResult<IReadOnlyList<NormalizedIssue>>(terminalIssues ?? []);
         }
+
+        public Task<IReadOnlyList<IssueStateSnapshot>> FetchIssueStatesByIdsAsync(
+            TrackerQuery query,
+            IReadOnlyList<string> issueIds,
+            CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult<IReadOnlyList<IssueStateSnapshot>>([]);
+        }
     }
 
     private sealed class FakeCoordinationStore(bool leaseGranted, IReadOnlySet<string>? unclaimableIssueIds = null) : IOrchestrationCoordinationStore


### PR DESCRIPTION
## Spec Alignment
Implements the next tracker slice from:
- Section 11.1 (required operation `fetch_issue_states_by_ids(issue_ids)`)
- Section 11.2 (GitHub query semantics + pagination integrity)
- Section 11.4 (error category `github_missing_end_cursor`)
- Section 17 (integration coverage for tracker behavior)

## Issue
Symphony could fetch candidate issues and terminal issues by state, but it did not yet expose a tracker operation for refreshing issue state by ID for reconciliation paths. Pagination handling for candidate issues also accepted `hasNextPage=true` with a missing/blank cursor, which can lead to silent truncation or unstable pagination behavior.

## User Impact
Without a state-by-ID refresh operation, active-run reconciliation cannot safely re-check the current tracker state for specific issues.
Without strict cursor validation, GitHub paging anomalies can produce incomplete candidate lists without a clear failure signal.

## Root Cause
The tracker adapter interface only implemented two operations and lacked a normalized state snapshot model.
The issues paging loop trusted `endCursor` shape when `hasNextPage` was true instead of enforcing the contract.

## Fix
- Added `IssueStateSnapshot` domain model.
- Extended `IGitHubTrackerClient` with `FetchIssueStatesByIdsAsync`.
- Implemented GraphQL `nodes(ids: ...)` state refresh in `GitHubTrackerClient`:
  - batches up to 100 IDs per request,
  - filters nodes to configured `owner/repo`,
  - normalizes `OPEN/CLOSED` to `Open/Closed`,
  - returns results in requested ID order for IDs that resolve in-scope.
- Hardened candidate pagination logic:
  - if `hasNextPage == true` and `endCursor` is missing/blank, throw `github_missing_end_cursor`.

## Tests
Added/updated integration coverage:
- `FetchCandidateIssuesAsync_ShouldFailWhenNextPageCursorMissing`
- `FetchIssueStatesByIdsAsync_ShouldReturnOnlyScopedIssueStates`
- Updated tracker fake in orchestration tests to satisfy the expanded interface

Validation run:
- `dotnet test Symphony.slnx -c Debug` (pass)
