### PR TITLE
Codex/release packaging installer

### DIFF
--- a/docs/PackageGuide.md
+++ b/docs/PackageGuide.md
@@ -36,6 +36,15 @@ The text-mode installer prompts for:
 - Instance folder
 - HTTP port
 
+Before the installer auto-starts Symphony, it also checks the local Codex CLI:
+
+- `codex --version` must be present and at least the Symphony-validated version
+- if npm can be reached, the installed CLI must not be behind the latest `@openai/codex` version
+- Codex authentication must succeed via `codex login status`
+- `auth.json` must exist under `~/.codex/` (or `CODEX_HOME` when set)
+
+If one of those checks fails, the installer pauses and tells you what to fix before the first start. With `--no-launch`, installation still completes, but the installer prints the Codex prerequisites you need to fix before running the instance later.
+
 It then creates an isolated instance with:
 
 - its own `WORKFLOW.md`

--- a/src/Symphony.Host/Setup/CodexCliPreflightEvaluator.cs
+++ b/src/Symphony.Host/Setup/CodexCliPreflightEvaluator.cs
@@ -1,0 +1,410 @@
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Text.Json;
+
+namespace Symphony.Host.Setup;
+
+internal static class CodexCliPreflightEvaluator
+{
+    internal const string ValidatedNpmVersion = "0.114.0";
+    internal static readonly TimeSpan DefaultProbeTimeout = TimeSpan.FromSeconds(10);
+    private const string CodexPackageName = "@openai/codex";
+    private const string AuthFileName = "auth.json";
+    private const string VersionCacheFileName = "version.json";
+
+    public static Task<CodexCliPreflightResult> CheckAsync(CancellationToken cancellationToken)
+    {
+        return CheckAsync(RunCommandAsync, ResolveCodexHomePath(), DefaultProbeTimeout, cancellationToken);
+    }
+
+    internal static async Task<CodexCliPreflightResult> CheckAsync(
+        Func<string, CancellationToken, Task<CodexCliCommandResult>> runCommandAsync,
+        string codexHomePath,
+        TimeSpan probeTimeout,
+        CancellationToken cancellationToken)
+    {
+        var blockingIssues = new List<string>();
+        var warnings = new List<string>();
+        var remediationSteps = new List<string>();
+        var authJsonPath = Path.Combine(codexHomePath, AuthFileName);
+        var hasAuthJson = File.Exists(authJsonPath);
+        var validatedVersion = CodexCliVersion.Parse(ValidatedNpmVersion);
+
+        string? installedVersionText = null;
+        string? latestVersionText = null;
+        string? latestVersionSource = null;
+        var latestVersionVerified = false;
+        var loginConfigured = false;
+        CodexCliVersion installedVersion = default;
+
+        var installedVersionResult = await SafeRunAsync(
+            runCommandAsync,
+            "codex --version",
+            probeTimeout,
+            cancellationToken);
+        var hasInstalledVersion = installedVersionResult is { ExitCode: 0 } &&
+            CodexCliVersion.TryParse(installedVersionResult.StandardOutput, out installedVersion);
+
+        if (!hasInstalledVersion)
+        {
+            blockingIssues.Add("Codex CLI is not installed or `codex --version` did not report a usable version.");
+            AddUnique(
+                remediationSteps,
+                $"Install Codex CLI with `npm install -g {CodexPackageName}@{ValidatedNpmVersion}`.");
+        }
+        else
+        {
+            installedVersionText = installedVersion.ToString();
+
+            if (installedVersion.CompareTo(validatedVersion) < 0)
+            {
+                blockingIssues.Add(
+                    $"Codex CLI {installedVersionText} is older than the Symphony-validated version {validatedVersion}.");
+                AddUnique(
+                    remediationSteps,
+                    $"Update Codex CLI with `npm install -g {CodexPackageName}@{ValidatedNpmVersion}`.");
+            }
+
+            var latestVersion = await ResolveLatestVersionAsync(
+                runCommandAsync,
+                codexHomePath,
+                probeTimeout,
+                cancellationToken);
+            if (latestVersion.Version is not null)
+            {
+                latestVersionText = latestVersion.Version.Value.ToString();
+                latestVersionSource = latestVersion.Source;
+                latestVersionVerified = latestVersion.Source is "npm";
+
+                if (installedVersion.CompareTo(latestVersion.Version.Value) < 0)
+                {
+                    blockingIssues.Add(
+                        $"Codex CLI {installedVersionText} is behind the latest available version {latestVersionText}.");
+                    AddUnique(
+                        remediationSteps,
+                        $"Update Codex CLI with `npm install -g {CodexPackageName}@{latestVersionText}`.");
+                }
+                else if (!latestVersionVerified)
+                {
+                    warnings.Add(
+                        $"Could not verify the latest Codex CLI version from npm; used the local Codex version cache instead ({latestVersionText}).");
+                }
+            }
+            else
+            {
+                warnings.Add(
+                    "Could not verify the latest Codex CLI version from npm or the local Codex version cache.");
+            }
+
+            var loginStatus = await SafeRunAsync(
+                runCommandAsync,
+                "codex login status",
+                probeTimeout,
+                cancellationToken);
+            loginConfigured = loginStatus is { ExitCode: 0 };
+            if (!loginConfigured)
+            {
+                blockingIssues.Add("Codex authentication is not configured or `codex login status` failed.");
+                AddUnique(
+                    remediationSteps,
+                    "Run `codex login` in another terminal, finish the sign-in flow, then return here.");
+            }
+        }
+
+        if (!hasAuthJson)
+        {
+            blockingIssues.Add($"Codex auth file is missing: '{authJsonPath}'.");
+            AddUnique(
+                remediationSteps,
+                $"Make sure Codex writes credentials to '{authJsonPath}' before starting Symphony.");
+        }
+
+        return new CodexCliPreflightResult(
+            installedVersionText,
+            validatedVersion.ToString(),
+            latestVersionText,
+            latestVersionSource,
+            latestVersionVerified,
+            authJsonPath,
+            hasAuthJson,
+            loginConfigured,
+            blockingIssues,
+            warnings,
+            remediationSteps);
+    }
+
+    private static async Task<CodexCliCommandResult?> SafeRunAsync(
+        Func<string, CancellationToken, Task<CodexCliCommandResult>> runCommandAsync,
+        string command,
+        TimeSpan probeTimeout,
+        CancellationToken cancellationToken)
+    {
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeoutCts.CancelAfter(probeTimeout);
+
+        try
+        {
+            return await runCommandAsync(command, timeoutCts.Token);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static async Task<(CodexCliVersion? Version, string? Source)> ResolveLatestVersionAsync(
+        Func<string, CancellationToken, Task<CodexCliCommandResult>> runCommandAsync,
+        string codexHomePath,
+        TimeSpan probeTimeout,
+        CancellationToken cancellationToken)
+    {
+        var npmResult = await SafeRunAsync(
+            runCommandAsync,
+            $"npm view {CodexPackageName} version",
+            probeTimeout,
+            cancellationToken);
+        if (npmResult is { ExitCode: 0 } &&
+            CodexCliVersion.TryParse(npmResult.StandardOutput, out var npmVersion))
+        {
+            return (npmVersion, "npm");
+        }
+
+        var versionCachePath = Path.Combine(codexHomePath, VersionCacheFileName);
+        if (!File.Exists(versionCachePath))
+        {
+            return (null, null);
+        }
+
+        try
+        {
+            await using var versionCacheStream = File.OpenRead(versionCachePath);
+            using var document = await JsonDocument.ParseAsync(versionCacheStream, cancellationToken: cancellationToken);
+            if (document.RootElement.TryGetProperty("latest_version", out var latestVersionProperty) &&
+                latestVersionProperty.ValueKind is JsonValueKind.String &&
+                CodexCliVersion.TryParse(latestVersionProperty.GetString(), out var cachedVersion))
+            {
+                return (cachedVersion, "cache");
+            }
+        }
+        catch (IOException)
+        {
+        }
+        catch (JsonException)
+        {
+        }
+
+        return (null, null);
+    }
+
+    private static async Task<CodexCliCommandResult> RunCommandAsync(string command, CancellationToken cancellationToken)
+    {
+        using var process = new Process
+        {
+            StartInfo = BuildProcessStartInfo(command)
+        };
+
+        if (!process.Start())
+        {
+            return new CodexCliCommandResult(-1, string.Empty, $"Failed to start command '{command}'.");
+        }
+
+        var standardOutputTask = process.StandardOutput.ReadToEndAsync(cancellationToken);
+        var standardErrorTask = process.StandardError.ReadToEndAsync(cancellationToken);
+
+        await process.WaitForExitAsync(cancellationToken);
+
+        return new CodexCliCommandResult(
+            process.ExitCode,
+            await standardOutputTask,
+            await standardErrorTask);
+    }
+
+    private static ProcessStartInfo BuildProcessStartInfo(string command)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            CreateNoWindow = true,
+            WorkingDirectory = Environment.CurrentDirectory
+        };
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            startInfo.FileName = "cmd.exe";
+            startInfo.ArgumentList.Add("/d");
+            startInfo.ArgumentList.Add("/s");
+            startInfo.ArgumentList.Add("/c");
+            startInfo.ArgumentList.Add(command);
+            return startInfo;
+        }
+
+        startInfo.FileName = "/bin/bash";
+        startInfo.ArgumentList.Add("-lc");
+        startInfo.ArgumentList.Add(command);
+        return startInfo;
+    }
+
+    private static string ResolveCodexHomePath()
+    {
+        var configuredCodexHome = Environment.GetEnvironmentVariable("CODEX_HOME");
+        if (!string.IsNullOrWhiteSpace(configuredCodexHome))
+        {
+            return Path.GetFullPath(configuredCodexHome);
+        }
+
+        var userProfile = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        if (!string.IsNullOrWhiteSpace(userProfile))
+        {
+            return Path.Combine(userProfile, ".codex");
+        }
+
+        return Path.Combine(Environment.CurrentDirectory, ".codex");
+    }
+
+    private static void AddUnique(ICollection<string> items, string value)
+    {
+        if (!items.Contains(value))
+        {
+            items.Add(value);
+        }
+    }
+}
+
+internal sealed record CodexCliPreflightResult(
+    string? InstalledVersion,
+    string ValidatedVersion,
+    string? LatestVersion,
+    string? LatestVersionSource,
+    bool LatestVersionVerified,
+    string AuthJsonPath,
+    bool HasAuthJson,
+    bool LoginConfigured,
+    IReadOnlyList<string> BlockingIssues,
+    IReadOnlyList<string> Warnings,
+    IReadOnlyList<string> RemediationSteps)
+{
+    public bool IsReadyToStart => BlockingIssues.Count == 0;
+}
+
+internal sealed record CodexCliCommandResult(
+    int ExitCode,
+    string StandardOutput,
+    string StandardError);
+
+internal readonly record struct CodexCliVersion(
+    int Major,
+    int Minor,
+    int Patch,
+    string? Suffix) : IComparable<CodexCliVersion>
+{
+    public static CodexCliVersion Parse(string value)
+    {
+        return TryParse(value, out var version)
+            ? version
+            : throw new FormatException($"'{value}' is not a valid Codex CLI version.");
+    }
+
+    public static bool TryParse(string? value, out CodexCliVersion version)
+    {
+        version = default;
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return false;
+        }
+
+        var token = value
+            .Split(new[] { ' ', '\t', '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)
+            .FirstOrDefault(segment => char.IsDigit(segment[0]));
+
+        if (token is null)
+        {
+            return false;
+        }
+
+        var plusIndex = token.IndexOf('+');
+        if (plusIndex >= 0)
+        {
+            token = token[..plusIndex];
+        }
+
+        string? suffix = null;
+        var dashIndex = token.IndexOf('-');
+        if (dashIndex >= 0)
+        {
+            suffix = token[(dashIndex + 1)..];
+            token = token[..dashIndex];
+        }
+
+        var parts = token.Split('.', StringSplitOptions.RemoveEmptyEntries);
+        if (parts.Length is < 2 or > 3)
+        {
+            return false;
+        }
+
+        if (!int.TryParse(parts[0], out var major) ||
+            !int.TryParse(parts[1], out var minor))
+        {
+            return false;
+        }
+
+        var patch = 0;
+        if (parts.Length == 3 && !int.TryParse(parts[2], out patch))
+        {
+            return false;
+        }
+
+        version = new CodexCliVersion(major, minor, patch, string.IsNullOrWhiteSpace(suffix) ? null : suffix);
+        return true;
+    }
+
+    public int CompareTo(CodexCliVersion other)
+    {
+        var majorCompare = Major.CompareTo(other.Major);
+        if (majorCompare != 0)
+        {
+            return majorCompare;
+        }
+
+        var minorCompare = Minor.CompareTo(other.Minor);
+        if (minorCompare != 0)
+        {
+            return minorCompare;
+        }
+
+        var patchCompare = Patch.CompareTo(other.Patch);
+        if (patchCompare != 0)
+        {
+            return patchCompare;
+        }
+
+        if (string.IsNullOrWhiteSpace(Suffix) && string.IsNullOrWhiteSpace(other.Suffix))
+        {
+            return 0;
+        }
+
+        if (string.IsNullOrWhiteSpace(Suffix))
+        {
+            return 1;
+        }
+
+        if (string.IsNullOrWhiteSpace(other.Suffix))
+        {
+            return -1;
+        }
+
+        return string.Compare(Suffix, other.Suffix, StringComparison.OrdinalIgnoreCase);
+    }
+
+    public override string ToString()
+    {
+        return string.IsNullOrWhiteSpace(Suffix)
+            ? $"{Major}.{Minor}.{Patch}"
+            : $"{Major}.{Minor}.{Patch}-{Suffix}";
+    }
+}

--- a/src/Symphony.Host/Setup/SymphonyInstallCommand.cs
+++ b/src/Symphony.Host/Setup/SymphonyInstallCommand.cs
@@ -43,7 +43,8 @@ internal static class SymphonyInstallCommand
 
                 Interactive installer for a self-contained Symphony instance.
                 The installer creates a dedicated WORKFLOW.md, appsettings.json,
-                .env, and run scripts in the selected folder.
+                .env, and run scripts in the selected folder. Before launch,
+                it also checks the local Codex CLI version and auth state.
                 """);
             return 0;
         }
@@ -144,7 +145,19 @@ internal static class SymphonyInstallCommand
         await output.WriteLineAsync($"Instance URL: {url}");
         await output.WriteLineAsync($"Start again later with '{GetPreferredRunCommand()}' from the instance folder.");
 
+        var codexReady = await EnsureCodexReadyAsync(
+            options,
+            input,
+            output,
+            runtime,
+            cancellationToken);
+
         if (options.NoLaunch)
+        {
+            return 0;
+        }
+
+        if (!codexReady)
         {
             return 0;
         }
@@ -190,6 +203,50 @@ internal static class SymphonyInstallCommand
         return process.ExitCode;
     }
 
+    private static async Task<bool> EnsureCodexReadyAsync(
+        InstallCommandOptions options,
+        TextReader input,
+        TextWriter output,
+        SymphonyInstallationRuntime runtime,
+        CancellationToken cancellationToken)
+    {
+        while (true)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var preflight = await runtime.CodexCliPreflightAsync(cancellationToken);
+            await WriteCodexPreflightAsync(output, preflight, cancellationToken);
+
+            if (preflight.IsReadyToStart)
+            {
+                return true;
+            }
+
+            await output.WriteLineAsync("Fix the Codex CLI items above before Symphony starts.");
+
+            if (options.NoLaunch)
+            {
+                await output.WriteLineAsync($"Before your first run, fix the Codex CLI items above and then start Symphony with '{GetPreferredRunCommand()}'.");
+                return false;
+            }
+
+            var retry = await PromptConfirmationAsync(
+                input,
+                output,
+                "Re-check Codex CLI after you update/sign in?",
+                defaultValue: true,
+                cancellationToken);
+
+            if (!retry)
+            {
+                await output.WriteLineAsync("Codex is not ready; installation has completed, but Symphony will not be started automatically.");
+                return false;
+            }
+
+            await output.WriteLineAsync("Re-checking Codex CLI...");
+        }
+    }
+
     private static async Task CopyBundleAsync(string sourceRoot, string destinationRoot, CancellationToken cancellationToken)
     {
         if (PathsEqual(sourceRoot, destinationRoot))
@@ -217,6 +274,68 @@ internal static class SymphonyInstallCommand
             File.Copy(sourceFile, destinationFile, overwrite: true);
             TryCopyUnixMode(sourceFile, destinationFile);
         }
+    }
+
+    private static async Task WriteCodexPreflightAsync(
+        TextWriter output,
+        CodexCliPreflightResult preflight,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        await output.WriteLineAsync(string.Empty);
+        await output.WriteLineAsync("Codex CLI check:");
+        await output.WriteLineAsync($"- Installed version: {preflight.InstalledVersion ?? "not found"}");
+        await output.WriteLineAsync($"- Symphony validated version: {preflight.ValidatedVersion}");
+        await output.WriteLineAsync($"- Latest available version: {FormatLatestVersion(preflight)}");
+        await output.WriteLineAsync($"- Auth file: {preflight.AuthJsonPath}");
+        await output.WriteLineAsync($"- Auth file present: {(preflight.HasAuthJson ? "yes" : "no")}");
+        await output.WriteLineAsync($"- Login status: {(preflight.LoginConfigured ? "ready" : "not ready")}");
+
+        if (preflight.Warnings.Count > 0)
+        {
+            await output.WriteLineAsync("Notes:");
+            foreach (var warning in preflight.Warnings)
+            {
+                await output.WriteLineAsync($"- {warning}");
+            }
+        }
+
+        if (preflight.IsReadyToStart)
+        {
+            await output.WriteLineAsync("Codex CLI is ready.");
+            return;
+        }
+
+        await output.WriteLineAsync("Before starting Symphony, fix these Codex CLI items:");
+        foreach (var issue in preflight.BlockingIssues)
+        {
+            await output.WriteLineAsync($"- {issue}");
+        }
+
+        if (preflight.RemediationSteps.Count > 0)
+        {
+            await output.WriteLineAsync("Suggested next steps:");
+            foreach (var step in preflight.RemediationSteps)
+            {
+                await output.WriteLineAsync($"- {step}");
+            }
+        }
+    }
+
+    private static string FormatLatestVersion(CodexCliPreflightResult preflight)
+    {
+        if (string.IsNullOrWhiteSpace(preflight.LatestVersion))
+        {
+            return "unavailable";
+        }
+
+        if (string.IsNullOrWhiteSpace(preflight.LatestVersionSource))
+        {
+            return preflight.LatestVersion;
+        }
+
+        return $"{preflight.LatestVersion} ({preflight.LatestVersionSource})";
     }
 
     private static bool ShouldExclude(string relativePath)

--- a/src/Symphony.Host/Setup/SymphonyInstallationRuntime.cs
+++ b/src/Symphony.Host/Setup/SymphonyInstallationRuntime.cs
@@ -6,6 +6,8 @@ internal sealed record SymphonyInstallationRuntime(
     string WindowsSetupScriptFileName,
     string UnixSetupScriptFileName)
 {
+    public Func<CancellationToken, Task<CodexCliPreflightResult>> CodexCliPreflightAsync { get; init; } = CodexCliPreflightEvaluator.CheckAsync;
+
     public static SymphonyInstallationRuntime CreateDefault()
     {
         return new SymphonyInstallationRuntime(

--- a/tests/Symphony.Integration.Tests/CodexCliPreflightEvaluatorTests.cs
+++ b/tests/Symphony.Integration.Tests/CodexCliPreflightEvaluatorTests.cs
@@ -1,0 +1,244 @@
+using Symphony.Host.Setup;
+
+namespace Symphony.Integration.Tests;
+
+public sealed class CodexCliPreflightEvaluatorTests
+{
+    [Fact]
+    public async Task CheckAsync_ShouldAcceptReadyCodexCli()
+    {
+        var codexHome = CreateTempDirectory("codex-home");
+
+        try
+        {
+            await File.WriteAllTextAsync(Path.Combine(codexHome, "auth.json"), "{}");
+
+            var result = await CodexCliPreflightEvaluator.CheckAsync(
+                CreateRunner(new Dictionary<string, CodexCliCommandResult>(StringComparer.Ordinal)
+                {
+                    ["codex --version"] = new(0, "codex-cli 0.114.0", string.Empty),
+                    ["npm view @openai/codex version"] = new(0, "0.114.0", string.Empty),
+                    ["codex login status"] = new(0, "Logged in using ChatGPT", string.Empty)
+                }),
+                codexHome,
+                TimeSpan.FromSeconds(1),
+                CancellationToken.None);
+
+            Assert.True(result.IsReadyToStart);
+            Assert.Equal("0.114.0", result.InstalledVersion);
+            Assert.Equal("0.114.0", result.LatestVersion);
+            Assert.True(result.LatestVersionVerified);
+            Assert.True(result.HasAuthJson);
+            Assert.True(result.LoginConfigured);
+        }
+        finally
+        {
+            TryDeleteDirectory(codexHome);
+        }
+    }
+
+    [Fact]
+    public async Task CheckAsync_ShouldBlockWhenInstalledVersionIsBehindValidatedVersion()
+    {
+        var codexHome = CreateTempDirectory("codex-home");
+
+        try
+        {
+            await File.WriteAllTextAsync(Path.Combine(codexHome, "auth.json"), "{}");
+
+            var result = await CodexCliPreflightEvaluator.CheckAsync(
+                CreateRunner(new Dictionary<string, CodexCliCommandResult>(StringComparer.Ordinal)
+                {
+                    ["codex --version"] = new(0, "codex-cli 0.113.0", string.Empty),
+                    ["npm view @openai/codex version"] = new(0, "0.114.0", string.Empty),
+                    ["codex login status"] = new(0, "Logged in using ChatGPT", string.Empty)
+                }),
+                codexHome,
+                TimeSpan.FromSeconds(1),
+                CancellationToken.None);
+
+            Assert.False(result.IsReadyToStart);
+            Assert.Contains(
+                result.BlockingIssues,
+                issue => issue.Contains("Symphony-validated version 0.114.0", StringComparison.Ordinal));
+        }
+        finally
+        {
+            TryDeleteDirectory(codexHome);
+        }
+    }
+
+    [Fact]
+    public async Task CheckAsync_ShouldBlockWhenAuthJsonIsMissing()
+    {
+        var codexHome = CreateTempDirectory("codex-home");
+
+        try
+        {
+            var result = await CodexCliPreflightEvaluator.CheckAsync(
+                CreateRunner(new Dictionary<string, CodexCliCommandResult>(StringComparer.Ordinal)
+                {
+                    ["codex --version"] = new(0, "codex-cli 0.114.0", string.Empty),
+                    ["npm view @openai/codex version"] = new(0, "0.114.0", string.Empty),
+                    ["codex login status"] = new(0, "Logged in using ChatGPT", string.Empty)
+                }),
+                codexHome,
+                TimeSpan.FromSeconds(1),
+                CancellationToken.None);
+
+            Assert.False(result.IsReadyToStart);
+            Assert.Contains(
+                result.BlockingIssues,
+                issue => issue.Contains("auth file is missing", StringComparison.OrdinalIgnoreCase));
+        }
+        finally
+        {
+            TryDeleteDirectory(codexHome);
+        }
+    }
+
+    [Fact]
+    public async Task CheckAsync_ShouldFallbackToLocalVersionCacheWhenNpmLookupFails()
+    {
+        var codexHome = CreateTempDirectory("codex-home");
+
+        try
+        {
+            await File.WriteAllTextAsync(Path.Combine(codexHome, "auth.json"), "{}");
+            await File.WriteAllTextAsync(
+                Path.Combine(codexHome, "version.json"),
+                """
+                {
+                  "latest_version": "0.114.0"
+                }
+                """);
+
+            var result = await CodexCliPreflightEvaluator.CheckAsync(
+                CreateRunner(new Dictionary<string, CodexCliCommandResult>(StringComparer.Ordinal)
+                {
+                    ["codex --version"] = new(0, "codex-cli 0.114.0", string.Empty),
+                    ["npm view @openai/codex version"] = new(1, string.Empty, "npm unavailable"),
+                    ["codex login status"] = new(0, "Logged in using ChatGPT", string.Empty)
+                }),
+                codexHome,
+                TimeSpan.FromSeconds(1),
+                CancellationToken.None);
+
+            Assert.True(result.IsReadyToStart);
+            Assert.Equal("cache", result.LatestVersionSource);
+            Assert.False(result.LatestVersionVerified);
+            Assert.Contains(
+                result.Warnings,
+                warning => warning.Contains("local Codex version cache", StringComparison.OrdinalIgnoreCase));
+        }
+        finally
+        {
+            TryDeleteDirectory(codexHome);
+        }
+    }
+
+    [Fact]
+    public async Task CheckAsync_ShouldPropagateCallerCancellation()
+    {
+        using var cancellationTokenSource = new CancellationTokenSource();
+        cancellationTokenSource.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            CodexCliPreflightEvaluator.CheckAsync(
+                (_, token) => Task.FromCanceled<CodexCliCommandResult>(token),
+                Path.Combine(Path.GetTempPath(), $"symphony-codex-home-{Guid.NewGuid():N}"),
+                TimeSpan.FromSeconds(1),
+                cancellationTokenSource.Token));
+    }
+
+    [Fact]
+    public async Task CheckAsync_ShouldTreatTimedOutNpmProbeAsUnverifiedLatestVersion()
+    {
+        var codexHome = CreateTempDirectory("codex-home");
+
+        try
+        {
+            await File.WriteAllTextAsync(Path.Combine(codexHome, "auth.json"), "{}");
+            await File.WriteAllTextAsync(
+                Path.Combine(codexHome, "version.json"),
+                """
+                {
+                  "latest_version": "0.114.0"
+                }
+                """);
+
+            var result = await CodexCliPreflightEvaluator.CheckAsync(
+                (command, token) => command.Equals("npm view @openai/codex version", StringComparison.Ordinal)
+                    ? WaitForCancellationAsync(token)
+                    : Task.FromResult(command switch
+                    {
+                        "codex --version" => new CodexCliCommandResult(0, "codex-cli 0.114.0", string.Empty),
+                        "codex login status" => new CodexCliCommandResult(0, "Logged in using ChatGPT", string.Empty),
+                        _ => throw new InvalidOperationException($"Unexpected command '{command}'.")
+                    }),
+                codexHome,
+                TimeSpan.FromMilliseconds(50),
+                CancellationToken.None);
+
+            Assert.True(result.IsReadyToStart);
+            Assert.Equal("cache", result.LatestVersionSource);
+            Assert.False(result.LatestVersionVerified);
+        }
+        finally
+        {
+            TryDeleteDirectory(codexHome);
+        }
+    }
+
+    private static Func<string, CancellationToken, Task<CodexCliCommandResult>> CreateRunner(
+        IReadOnlyDictionary<string, CodexCliCommandResult> responses)
+    {
+        return (command, _) =>
+        {
+            if (!responses.TryGetValue(command, out var response))
+            {
+                throw new InvalidOperationException($"No fake response configured for '{command}'.");
+            }
+
+            return Task.FromResult(response);
+        };
+    }
+
+    private static string CreateTempDirectory(string prefix)
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"symphony-{prefix}-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(path);
+        return path;
+    }
+
+    private static async Task<CodexCliCommandResult> WaitForCancellationAsync(CancellationToken cancellationToken)
+    {
+        await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+        throw new InvalidOperationException("Expected cancellation before completion.");
+    }
+
+    private static void TryDeleteDirectory(string path)
+    {
+        if (!Directory.Exists(path))
+        {
+            return;
+        }
+
+        for (var attempt = 0; attempt < 5; attempt++)
+        {
+            try
+            {
+                Directory.Delete(path, recursive: true);
+                return;
+            }
+            catch (IOException) when (attempt < 4)
+            {
+                Thread.Sleep(100);
+            }
+            catch (UnauthorizedAccessException) when (attempt < 4)
+            {
+                Thread.Sleep(100);
+            }
+        }
+    }
+}

--- a/tests/Symphony.Integration.Tests/InstallCommandTests.cs
+++ b/tests/Symphony.Integration.Tests/InstallCommandTests.cs
@@ -40,7 +40,7 @@ public sealed class InstallCommandTests
                 output,
                 error,
                 CancellationToken.None,
-                new SymphonyInstallationRuntime(bundleRoot, executableName, "setup-symphony.cmd", "setup-symphony.sh"));
+                CreateRuntime(bundleRoot, executableName, readyToStart: true));
 
             Assert.Equal(0, exitCode);
             Assert.Equal(string.Empty, error.ToString());
@@ -97,7 +97,7 @@ public sealed class InstallCommandTests
                     TextWriter.Null,
                     TextWriter.Null,
                     CancellationToken.None,
-                    new SymphonyInstallationRuntime(bundleRoot, executableName, "setup-symphony.cmd", "setup-symphony.sh")));
+                    CreateRuntime(bundleRoot, executableName, readyToStart: true)));
 
             Assert.Contains("GitHub token input ended unexpectedly.", ex.Message, StringComparison.Ordinal);
         }
@@ -127,7 +127,7 @@ public sealed class InstallCommandTests
                     TextWriter.Null,
                     TextWriter.Null,
                     CancellationToken.None,
-                    new SymphonyInstallationRuntime(bundleRoot, executableName, "setup-symphony.cmd", "setup-symphony.sh")));
+                    CreateRuntime(bundleRoot, executableName, readyToStart: true)));
 
             Assert.Contains("GitHub owner input ended unexpectedly.", ex.Message, StringComparison.Ordinal);
         }
@@ -149,11 +149,141 @@ public sealed class InstallCommandTests
         Assert.True(parsed.ShowHelp);
     }
 
+    [Fact]
+    public async Task RunAsync_ShouldBlockLaunchWhenCodexCliIsNotReady()
+    {
+        var bundleRoot = CreateTempDirectory("bundle");
+        var installRoot = CreateTempDirectory("install");
+        var executableName = OperatingSystem.IsWindows() ? "Symphony.exe" : "Symphony";
+
+        try
+        {
+            await File.WriteAllTextAsync(Path.Combine(bundleRoot, executableName), "binary");
+            await File.WriteAllTextAsync(Path.Combine(bundleRoot, "setup-symphony.cmd"), "@echo off");
+            await File.WriteAllTextAsync(Path.Combine(bundleRoot, "setup-symphony.sh"), "#!/usr/bin/env bash");
+
+            var input = new StringReader($"""
+                github_pat_testtoken
+                releasedgroup
+                symphony
+                main
+                {installRoot}
+                43123
+                n
+                """);
+            var output = new StringWriter();
+
+            var exitCode = await SymphonyInstallCommand.RunAsync(
+                new InstallCommandOptions(NoLaunch: false, ShowHelp: false),
+                input,
+                output,
+                TextWriter.Null,
+                CancellationToken.None,
+                CreateRuntime(bundleRoot, executableName, readyToStart: false));
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Codex CLI check:", output.ToString(), StringComparison.Ordinal);
+            Assert.Contains("Fix the Codex CLI items above before Symphony starts.", output.ToString(), StringComparison.Ordinal);
+            Assert.Contains("Codex is not ready; installation has completed, but Symphony will not be started automatically.", output.ToString(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            TryDeleteDirectory(bundleRoot);
+            TryDeleteDirectory(installRoot);
+        }
+    }
+
+    [Fact]
+    public async Task RunAsync_ShouldReportCodexCliIssuesForNoLaunchInstalls()
+    {
+        var bundleRoot = CreateTempDirectory("bundle");
+        var installRoot = CreateTempDirectory("install");
+        var executableName = OperatingSystem.IsWindows() ? "Symphony.exe" : "Symphony";
+
+        try
+        {
+            await File.WriteAllTextAsync(Path.Combine(bundleRoot, executableName), "binary");
+            await File.WriteAllTextAsync(Path.Combine(bundleRoot, "setup-symphony.cmd"), "@echo off");
+            await File.WriteAllTextAsync(Path.Combine(bundleRoot, "setup-symphony.sh"), "#!/usr/bin/env bash");
+
+            var input = new StringReader($"""
+                github_pat_testtoken
+                releasedgroup
+                symphony
+                main
+                {installRoot}
+                43123
+                """);
+            var output = new StringWriter();
+
+            var exitCode = await SymphonyInstallCommand.RunAsync(
+                new InstallCommandOptions(NoLaunch: true, ShowHelp: false),
+                input,
+                output,
+                TextWriter.Null,
+                CancellationToken.None,
+                CreateRuntime(bundleRoot, executableName, readyToStart: false));
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Before your first run, fix the Codex CLI items above", output.ToString(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            TryDeleteDirectory(bundleRoot);
+            TryDeleteDirectory(installRoot);
+        }
+    }
+
     private static string CreateTempDirectory(string prefix)
     {
         var path = Path.Combine(Path.GetTempPath(), $"symphony-{prefix}-{Guid.NewGuid():N}");
         Directory.CreateDirectory(path);
         return path;
+    }
+
+    private static SymphonyInstallationRuntime CreateRuntime(string bundleRoot, string executableName, bool readyToStart)
+    {
+        return new SymphonyInstallationRuntime(bundleRoot, executableName, "setup-symphony.cmd", "setup-symphony.sh")
+        {
+            CodexCliPreflightAsync = _ => Task.FromResult(CreatePreflightResult(readyToStart))
+        };
+    }
+
+    private static CodexCliPreflightResult CreatePreflightResult(bool readyToStart)
+    {
+        return readyToStart
+            ? new CodexCliPreflightResult(
+                InstalledVersion: "0.114.0",
+                ValidatedVersion: "0.114.0",
+                LatestVersion: "0.114.0",
+                LatestVersionSource: "npm",
+                LatestVersionVerified: true,
+                AuthJsonPath: Path.Combine(Path.GetTempPath(), ".codex", "auth.json"),
+                HasAuthJson: true,
+                LoginConfigured: true,
+                BlockingIssues: [],
+                Warnings: [],
+                RemediationSteps: [])
+            : new CodexCliPreflightResult(
+                InstalledVersion: "0.113.0",
+                ValidatedVersion: "0.114.0",
+                LatestVersion: "0.114.0",
+                LatestVersionSource: "npm",
+                LatestVersionVerified: true,
+                AuthJsonPath: Path.Combine(Path.GetTempPath(), ".codex", "auth.json"),
+                HasAuthJson: false,
+                LoginConfigured: false,
+                BlockingIssues:
+                [
+                    "Codex CLI 0.113.0 is older than the Symphony-validated version 0.114.0.",
+                    $"Codex auth file is missing: '{Path.Combine(Path.GetTempPath(), ".codex", "auth.json")}'."
+                ],
+                Warnings: [],
+                RemediationSteps:
+                [
+                    "Update Codex CLI with `npm install -g @openai/codex@0.114.0`.",
+                    "Run `codex login` in another terminal, finish the sign-in flow, then return here."
+                ]);
     }
 
     private static void TryDeleteDirectory(string path)


### PR DESCRIPTION
This pull request introduces a preflight check for the Codex CLI during Symphony installation, ensuring the CLI is properly installed, up-to-date, and authenticated before Symphony can start. The installer now pauses and provides actionable feedback if Codex prerequisites are not met, improving reliability and user guidance. Comprehensive tests were added to verify various Codex CLI readiness scenarios.

Codex CLI preflight integration:

* Added a preflight check in `SymphonyInstallCommand` to verify Codex CLI version, authentication status, and presence of `auth.json` before launching Symphony. If checks fail, the installer pauses and instructs the user on remediation steps, or completes installation without auto-launch if `--no-launch` is used. (`src/Symphony.Host/Setup/SymphonyInstallCommand.cs`) [[1]](diffhunk://#diff-2dc91ae65156759867336979910b29e9b90cfadb5488aedef6300bc9488f7ad0R148-R164) [[2]](diffhunk://#diff-2dc91ae65156759867336979910b29e9b90cfadb5488aedef6300bc9488f7ad0R206-R249) [[3]](diffhunk://#diff-2dc91ae65156759867336979910b29e9b90cfadb5488aedef6300bc9488f7ad0R279-R340)
* Updated `SymphonyInstallationRuntime` to expose `CodexCliPreflightAsync` for dependency injection and testing. (`src/Symphony.Host/Setup/SymphonyInstallationRuntime.cs`)

User guidance and documentation:

* Improved installation documentation to describe Codex CLI checks and user-facing remediation steps. (`docs/PackageGuide.md`)
* Enhanced installer help output to mention Codex CLI readiness checks. (`src/Symphony.Host/Setup/SymphonyInstallCommand.cs`)

Testing and validation:

* Added integration tests for Codex CLI preflight evaluator, covering scenarios such as version mismatch, missing authentication, fallback to local cache, and cancellation handling. (`tests/Symphony.Integration.Tests/CodexCliPreflightEvaluatorTests.cs`)
* Updated install command tests to verify installer behavior when Codex CLI is not ready and when `--no-launch` is specified, including new helper methods for test setup. (`tests/Symphony.Integration.Tests/InstallCommandTests.cs`) [[1]](diffhunk://#diff-4317fe465ab2ca49da3b3f4beeaec034c012ee5a02efcb75820be81746f50d4cL43-R43) [[2]](diffhunk://#diff-4317fe465ab2ca49da3b3f4beeaec034c012ee5a02efcb75820be81746f50d4cL100-R100) [[3]](diffhunk://#diff-4317fe465ab2ca49da3b3f4beeaec034c012ee5a02efcb75820be81746f50d4cL130-R130) [[4]](diffhunk://#diff-4317fe465ab2ca49da3b3f4beeaec034c012ee5a02efcb75820be81746f50d4cR152-R288)