### PR TITLE
Revert PR #56: Avoid interactive Codex auth probe in installer preflight

### DIFF
--- a/docs/PackageGuide.md
+++ b/docs/PackageGuide.md
@@ -40,10 +40,10 @@ Before the installer auto-starts Symphony, it also checks the local Codex CLI:
 
 - `codex --version` must be present and at least the Symphony-validated version
 - if npm can be reached, the installed CLI must not be behind the latest `@openai/codex` version
+- Codex authentication must succeed via `codex login status`
 - `auth.json` must exist under `~/.codex/` (or `CODEX_HOME` when set)
-- the auth file must contain either a reusable login token set or `OPENAI_API_KEY`
 
-The installer validates the auth file directly and does not call `codex login status`, so the preflight stays non-interactive and avoids triggering external login flows such as Azure CLI auth. If one of those checks fails, the installer pauses and tells you what to fix before the first start. With `--no-launch`, installation still completes, but the installer prints the Codex prerequisites you need to fix before running the instance later.
+If one of those checks fails, the installer pauses and tells you what to fix before the first start. With `--no-launch`, installation still completes, but the installer prints the Codex prerequisites you need to fix before running the instance later.
 
 It then creates an isolated instance with:
 

--- a/src/Symphony.Host/Setup/CodexCliPreflightEvaluator.cs
+++ b/src/Symphony.Host/Setup/CodexCliPreflightEvaluator.cs
@@ -27,19 +27,15 @@ internal static class CodexCliPreflightEvaluator
         var warnings = new List<string>();
         var remediationSteps = new List<string>();
         var authJsonPath = Path.Combine(codexHomePath, AuthFileName);
-        var authInspection = await InspectAuthConfigurationAsync(authJsonPath, cancellationToken);
-        var hasAuthJson = authInspection.Exists;
+        var hasAuthJson = File.Exists(authJsonPath);
         var validatedVersion = CodexCliVersion.Parse(ValidatedNpmVersion);
 
         string? installedVersionText = null;
         string? latestVersionText = null;
         string? latestVersionSource = null;
         var latestVersionVerified = false;
-        var authenticationConfigured = authInspection.IsConfigured;
-        var authenticationMode = authInspection.Mode;
+        var loginConfigured = false;
         CodexCliVersion installedVersion = default;
-
-        string? authenticationBlockingIssue = null;
 
         var installedVersionResult = await SafeRunAsync(
             runCommandAsync,
@@ -100,30 +96,24 @@ internal static class CodexCliPreflightEvaluator
                     "Could not verify the latest Codex CLI version from npm or the local Codex version cache.");
             }
 
-        }
-
-        if (!authenticationConfigured)
-        {
-            authenticationBlockingIssue = !hasAuthJson
-                ? $"Codex auth file is missing: '{authJsonPath}'."
-                : !string.IsNullOrWhiteSpace(authInspection.Warning)
-                    ? authInspection.Warning
-                    : $"Codex auth file '{authJsonPath}' does not contain a usable authentication record.";
-
-            blockingIssues.Add(authenticationBlockingIssue);
-            AddUnique(
-                remediationSteps,
-                "Run `codex login` in another terminal or configure Codex API-key auth, then return here.");
-        }
-
-        if (!string.IsNullOrWhiteSpace(authInspection.Warning) &&
-            !string.Equals(authenticationBlockingIssue, authInspection.Warning, StringComparison.Ordinal))
-        {
-            warnings.Add(authInspection.Warning);
+            var loginStatus = await SafeRunAsync(
+                runCommandAsync,
+                "codex login status",
+                probeTimeout,
+                cancellationToken);
+            loginConfigured = loginStatus is { ExitCode: 0 };
+            if (!loginConfigured)
+            {
+                blockingIssues.Add("Codex authentication is not configured or `codex login status` failed.");
+                AddUnique(
+                    remediationSteps,
+                    "Run `codex login` in another terminal, finish the sign-in flow, then return here.");
+            }
         }
 
         if (!hasAuthJson)
         {
+            blockingIssues.Add($"Codex auth file is missing: '{authJsonPath}'.");
             AddUnique(
                 remediationSteps,
                 $"Make sure Codex writes credentials to '{authJsonPath}' before starting Symphony.");
@@ -137,8 +127,7 @@ internal static class CodexCliPreflightEvaluator
             latestVersionVerified,
             authJsonPath,
             hasAuthJson,
-            authenticationConfigured,
-            authenticationMode,
+            loginConfigured,
             blockingIssues,
             warnings,
             remediationSteps);
@@ -211,80 +200,6 @@ internal static class CodexCliPreflightEvaluator
         return (null, null);
     }
 
-    private static async Task<CodexCliAuthInspection> InspectAuthConfigurationAsync(
-        string authJsonPath,
-        CancellationToken cancellationToken)
-    {
-        if (!File.Exists(authJsonPath))
-        {
-            return new CodexCliAuthInspection(false, false, null, null);
-        }
-
-        try
-        {
-            await using var authStream = File.OpenRead(authJsonPath);
-            using var document = await JsonDocument.ParseAsync(authStream, cancellationToken: cancellationToken);
-            var root = document.RootElement;
-            if (root.ValueKind != JsonValueKind.Object)
-            {
-                return new CodexCliAuthInspection(
-                    true,
-                    false,
-                    null,
-                    "Codex auth file exists but is not a JSON object.");
-            }
-
-            var authMode = GetOptionalString(root, "auth_mode");
-            var hasApiKey = HasNonEmptyString(root, "OPENAI_API_KEY");
-            var hasReusableTokens = TryGetProperty(root, "tokens", out var tokensElement) &&
-                                    tokensElement.ValueKind is JsonValueKind.Object &&
-                                    (HasNonEmptyString(tokensElement, "access_token") ||
-                                     HasNonEmptyString(tokensElement, "refresh_token") ||
-                                     HasNonEmptyString(tokensElement, "id_token"));
-
-            if (string.IsNullOrWhiteSpace(authMode))
-            {
-                authMode = hasApiKey
-                    ? "api_key"
-                    : hasReusableTokens
-                        ? "login"
-                        : null;
-            }
-
-            return new CodexCliAuthInspection(
-                true,
-                hasApiKey || hasReusableTokens,
-                authMode,
-                hasApiKey || hasReusableTokens
-                    ? null
-                    : "Codex auth file exists but does not contain a reusable login token set or API key.");
-        }
-        catch (JsonException)
-        {
-            return new CodexCliAuthInspection(
-                true,
-                false,
-                null,
-                "Codex auth file exists but is not valid JSON.");
-        }
-        catch (IOException)
-        {
-            return new CodexCliAuthInspection(
-                true,
-                false,
-                null,
-                "Codex auth file exists but could not be read.");
-        }
-        catch (UnauthorizedAccessException)
-        {
-            return new CodexCliAuthInspection(
-                true,
-                false,
-                null,
-                "Codex auth file exists but could not be read.");
-        }
-    }
-
     private static async Task<CodexCliCommandResult> RunCommandAsync(string command, CancellationToken cancellationToken)
     {
         using var process = new Process
@@ -352,37 +267,6 @@ internal static class CodexCliPreflightEvaluator
         return Path.Combine(Environment.CurrentDirectory, ".codex");
     }
 
-    private static bool HasNonEmptyString(JsonElement element, string propertyName)
-    {
-        return TryGetProperty(element, propertyName, out var property) &&
-               property.ValueKind is JsonValueKind.String &&
-               !string.IsNullOrWhiteSpace(property.GetString());
-    }
-
-    private static string? GetOptionalString(JsonElement element, string propertyName)
-    {
-        return TryGetProperty(element, propertyName, out var property) &&
-               property.ValueKind is JsonValueKind.String
-            ? property.GetString()
-            : null;
-    }
-
-    private static bool TryGetProperty(JsonElement element, string propertyName, out JsonElement property)
-    {
-        foreach (var candidate in element.EnumerateObject())
-        {
-            if (candidate.NameEquals(propertyName) ||
-                candidate.Name.Equals(propertyName, StringComparison.OrdinalIgnoreCase))
-            {
-                property = candidate.Value;
-                return true;
-            }
-        }
-
-        property = default;
-        return false;
-    }
-
     private static void AddUnique(ICollection<string> items, string value)
     {
         if (!items.Contains(value))
@@ -400,20 +284,13 @@ internal sealed record CodexCliPreflightResult(
     bool LatestVersionVerified,
     string AuthJsonPath,
     bool HasAuthJson,
-    bool AuthenticationConfigured,
-    string? AuthenticationMode,
+    bool LoginConfigured,
     IReadOnlyList<string> BlockingIssues,
     IReadOnlyList<string> Warnings,
     IReadOnlyList<string> RemediationSteps)
 {
     public bool IsReadyToStart => BlockingIssues.Count == 0;
 }
-
-internal sealed record CodexCliAuthInspection(
-    bool Exists,
-    bool IsConfigured,
-    string? Mode,
-    string? Warning);
 
 internal sealed record CodexCliCommandResult(
     int ExitCode,

--- a/src/Symphony.Host/Setup/SymphonyInstallCommand.cs
+++ b/src/Symphony.Host/Setup/SymphonyInstallCommand.cs
@@ -290,8 +290,7 @@ internal static class SymphonyInstallCommand
         await output.WriteLineAsync($"- Latest available version: {FormatLatestVersion(preflight)}");
         await output.WriteLineAsync($"- Auth file: {preflight.AuthJsonPath}");
         await output.WriteLineAsync($"- Auth file present: {(preflight.HasAuthJson ? "yes" : "no")}");
-        await output.WriteLineAsync($"- Auth mode: {preflight.AuthenticationMode ?? "unknown"}");
-        await output.WriteLineAsync($"- Authentication status: {(preflight.AuthenticationConfigured ? "ready" : "not ready")}");
+        await output.WriteLineAsync($"- Login status: {(preflight.LoginConfigured ? "ready" : "not ready")}");
 
         if (preflight.Warnings.Count > 0)
         {

--- a/tests/Symphony.Integration.Tests/CodexCliPreflightEvaluatorTests.cs
+++ b/tests/Symphony.Integration.Tests/CodexCliPreflightEvaluatorTests.cs
@@ -11,13 +11,14 @@ public sealed class CodexCliPreflightEvaluatorTests
 
         try
         {
-            await File.WriteAllTextAsync(Path.Combine(codexHome, "auth.json"), CreateLoginAuthJson());
+            await File.WriteAllTextAsync(Path.Combine(codexHome, "auth.json"), "{}");
 
             var result = await CodexCliPreflightEvaluator.CheckAsync(
                 CreateRunner(new Dictionary<string, CodexCliCommandResult>(StringComparer.Ordinal)
                 {
                     ["codex --version"] = new(0, "codex-cli 0.114.0", string.Empty),
-                    ["npm view @openai/codex version"] = new(0, "0.114.0", string.Empty)
+                    ["npm view @openai/codex version"] = new(0, "0.114.0", string.Empty),
+                    ["codex login status"] = new(0, "Logged in using ChatGPT", string.Empty)
                 }),
                 codexHome,
                 TimeSpan.FromSeconds(1),
@@ -28,37 +29,7 @@ public sealed class CodexCliPreflightEvaluatorTests
             Assert.Equal("0.114.0", result.LatestVersion);
             Assert.True(result.LatestVersionVerified);
             Assert.True(result.HasAuthJson);
-            Assert.True(result.AuthenticationConfigured);
-            Assert.Equal("chatgpt", result.AuthenticationMode);
-        }
-        finally
-        {
-            TryDeleteDirectory(codexHome);
-        }
-    }
-
-    [Fact]
-    public async Task CheckAsync_ShouldAcceptApiKeyAuthFile()
-    {
-        var codexHome = CreateTempDirectory("codex-home");
-
-        try
-        {
-            await File.WriteAllTextAsync(Path.Combine(codexHome, "auth.json"), CreateApiKeyAuthJson());
-
-            var result = await CodexCliPreflightEvaluator.CheckAsync(
-                CreateRunner(new Dictionary<string, CodexCliCommandResult>(StringComparer.Ordinal)
-                {
-                    ["codex --version"] = new(0, "codex-cli 0.114.0", string.Empty),
-                    ["npm view @openai/codex version"] = new(0, "0.114.0", string.Empty)
-                }),
-                codexHome,
-                TimeSpan.FromSeconds(1),
-                CancellationToken.None);
-
-            Assert.True(result.IsReadyToStart);
-            Assert.True(result.AuthenticationConfigured);
-            Assert.Equal("api_key", result.AuthenticationMode);
+            Assert.True(result.LoginConfigured);
         }
         finally
         {
@@ -73,13 +44,14 @@ public sealed class CodexCliPreflightEvaluatorTests
 
         try
         {
-            await File.WriteAllTextAsync(Path.Combine(codexHome, "auth.json"), CreateLoginAuthJson());
+            await File.WriteAllTextAsync(Path.Combine(codexHome, "auth.json"), "{}");
 
             var result = await CodexCliPreflightEvaluator.CheckAsync(
                 CreateRunner(new Dictionary<string, CodexCliCommandResult>(StringComparer.Ordinal)
                 {
                     ["codex --version"] = new(0, "codex-cli 0.113.0", string.Empty),
-                    ["npm view @openai/codex version"] = new(0, "0.114.0", string.Empty)
+                    ["npm view @openai/codex version"] = new(0, "0.114.0", string.Empty),
+                    ["codex login status"] = new(0, "Logged in using ChatGPT", string.Empty)
                 }),
                 codexHome,
                 TimeSpan.FromSeconds(1),
@@ -107,7 +79,8 @@ public sealed class CodexCliPreflightEvaluatorTests
                 CreateRunner(new Dictionary<string, CodexCliCommandResult>(StringComparer.Ordinal)
                 {
                     ["codex --version"] = new(0, "codex-cli 0.114.0", string.Empty),
-                    ["npm view @openai/codex version"] = new(0, "0.114.0", string.Empty)
+                    ["npm view @openai/codex version"] = new(0, "0.114.0", string.Empty),
+                    ["codex login status"] = new(0, "Logged in using ChatGPT", string.Empty)
                 }),
                 codexHome,
                 TimeSpan.FromSeconds(1),
@@ -131,7 +104,7 @@ public sealed class CodexCliPreflightEvaluatorTests
 
         try
         {
-            await File.WriteAllTextAsync(Path.Combine(codexHome, "auth.json"), CreateLoginAuthJson());
+            await File.WriteAllTextAsync(Path.Combine(codexHome, "auth.json"), "{}");
             await File.WriteAllTextAsync(
                 Path.Combine(codexHome, "version.json"),
                 """
@@ -144,7 +117,8 @@ public sealed class CodexCliPreflightEvaluatorTests
                 CreateRunner(new Dictionary<string, CodexCliCommandResult>(StringComparer.Ordinal)
                 {
                     ["codex --version"] = new(0, "codex-cli 0.114.0", string.Empty),
-                    ["npm view @openai/codex version"] = new(1, string.Empty, "npm unavailable")
+                    ["npm view @openai/codex version"] = new(1, string.Empty, "npm unavailable"),
+                    ["codex login status"] = new(0, "Logged in using ChatGPT", string.Empty)
                 }),
                 codexHome,
                 TimeSpan.FromSeconds(1),
@@ -156,81 +130,6 @@ public sealed class CodexCliPreflightEvaluatorTests
             Assert.Contains(
                 result.Warnings,
                 warning => warning.Contains("local Codex version cache", StringComparison.OrdinalIgnoreCase));
-        }
-        finally
-        {
-            TryDeleteDirectory(codexHome);
-        }
-    }
-
-    [Fact]
-    public async Task CheckAsync_ShouldBlockWhenAuthJsonHasNoUsableCredentials()
-    {
-        var codexHome = CreateTempDirectory("codex-home");
-
-        try
-        {
-            await File.WriteAllTextAsync(
-                Path.Combine(codexHome, "auth.json"),
-                """
-                {
-                  "auth_mode": "chatgpt",
-                  "tokens": {}
-                }
-                """);
-
-            var result = await CodexCliPreflightEvaluator.CheckAsync(
-                CreateRunner(new Dictionary<string, CodexCliCommandResult>(StringComparer.Ordinal)
-                {
-                    ["codex --version"] = new(0, "codex-cli 0.114.0", string.Empty),
-                    ["npm view @openai/codex version"] = new(0, "0.114.0", string.Empty)
-                }),
-                codexHome,
-                TimeSpan.FromSeconds(1),
-                CancellationToken.None);
-
-            Assert.False(result.IsReadyToStart);
-            Assert.Contains(
-                result.BlockingIssues,
-                warning => warning.Contains("reusable login token set or API key", StringComparison.OrdinalIgnoreCase));
-            Assert.DoesNotContain(
-                result.Warnings,
-                warning => warning.Contains("reusable login token set or API key", StringComparison.OrdinalIgnoreCase));
-        }
-        finally
-        {
-            TryDeleteDirectory(codexHome);
-        }
-    }
-
-    [Fact]
-    public async Task CheckAsync_ShouldSurfaceInvalidAuthJsonAsBlockingIssue()
-    {
-        var codexHome = CreateTempDirectory("codex-home");
-
-        try
-        {
-            await File.WriteAllTextAsync(
-                Path.Combine(codexHome, "auth.json"),
-                "{ this is not valid json");
-
-            var result = await CodexCliPreflightEvaluator.CheckAsync(
-                CreateRunner(new Dictionary<string, CodexCliCommandResult>(StringComparer.Ordinal)
-                {
-                    ["codex --version"] = new(0, "codex-cli 0.114.0", string.Empty),
-                    ["npm view @openai/codex version"] = new(0, "0.114.0", string.Empty)
-                }),
-                codexHome,
-                TimeSpan.FromSeconds(1),
-                CancellationToken.None);
-
-            Assert.False(result.IsReadyToStart);
-            Assert.Contains(
-                result.BlockingIssues,
-                issue => issue.Contains("not valid JSON", StringComparison.OrdinalIgnoreCase));
-            Assert.DoesNotContain(
-                result.Warnings,
-                warning => warning.Contains("not valid JSON", StringComparison.OrdinalIgnoreCase));
         }
         finally
         {
@@ -259,7 +158,7 @@ public sealed class CodexCliPreflightEvaluatorTests
 
         try
         {
-            await File.WriteAllTextAsync(Path.Combine(codexHome, "auth.json"), CreateLoginAuthJson());
+            await File.WriteAllTextAsync(Path.Combine(codexHome, "auth.json"), "{}");
             await File.WriteAllTextAsync(
                 Path.Combine(codexHome, "version.json"),
                 """
@@ -274,6 +173,7 @@ public sealed class CodexCliPreflightEvaluatorTests
                     : Task.FromResult(command switch
                     {
                         "codex --version" => new CodexCliCommandResult(0, "codex-cli 0.114.0", string.Empty),
+                        "codex login status" => new CodexCliCommandResult(0, "Logged in using ChatGPT", string.Empty),
                         _ => throw new InvalidOperationException($"Unexpected command '{command}'.")
                     }),
                 codexHome,
@@ -302,32 +202,6 @@ public sealed class CodexCliPreflightEvaluatorTests
 
             return Task.FromResult(response);
         };
-    }
-
-    private static string CreateLoginAuthJson()
-    {
-        return """
-            {
-              "auth_mode": "chatgpt",
-              "tokens": {
-                "id_token": "id-token",
-                "access_token": "access-token",
-                "refresh_token": "refresh-token",
-                "account_id": "account-id"
-              },
-              "last_refresh": "2026-04-08T00:00:00Z"
-            }
-            """;
-    }
-
-    private static string CreateApiKeyAuthJson()
-    {
-        return """
-            {
-              "OPENAI_API_KEY": "sk-test",
-              "last_refresh": "2026-04-08T00:00:00Z"
-            }
-            """;
     }
 
     private static string CreateTempDirectory(string prefix)

--- a/tests/Symphony.Integration.Tests/InstallCommandTests.cs
+++ b/tests/Symphony.Integration.Tests/InstallCommandTests.cs
@@ -260,8 +260,7 @@ public sealed class InstallCommandTests
                 LatestVersionVerified: true,
                 AuthJsonPath: Path.Combine(Path.GetTempPath(), ".codex", "auth.json"),
                 HasAuthJson: true,
-                AuthenticationConfigured: true,
-                AuthenticationMode: "chatgpt",
+                LoginConfigured: true,
                 BlockingIssues: [],
                 Warnings: [],
                 RemediationSteps: [])
@@ -273,8 +272,7 @@ public sealed class InstallCommandTests
                 LatestVersionVerified: true,
                 AuthJsonPath: Path.Combine(Path.GetTempPath(), ".codex", "auth.json"),
                 HasAuthJson: false,
-                AuthenticationConfigured: false,
-                AuthenticationMode: null,
+                LoginConfigured: false,
                 BlockingIssues:
                 [
                     "Codex CLI 0.113.0 is older than the Symphony-validated version 0.114.0.",
@@ -284,7 +282,7 @@ public sealed class InstallCommandTests
                 RemediationSteps:
                 [
                     "Update Codex CLI with `npm install -g @openai/codex@0.114.0`.",
-                    "Run `codex login` in another terminal or configure Codex API-key auth, then return here."
+                    "Run `codex login` in another terminal, finish the sign-in flow, then return here."
                 ]);
     }
 


### PR DESCRIPTION
## Summary
- Reverts #56 which introduced changes to avoid interactive Codex auth probe in installer preflight

## Test plan
- [x] Verify installer preflight works correctly after revert

🤖 Generated with [Claude Code](https://claude.com/claude-code)