### PR TITLE
Fix terminal worktree cleanup and token reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ Release bundle installation guidance is in [docs/PackageGuide.md](docs/PackageGu
 - GitHub issue normalization now includes linked branch metadata, blocker references, milestone data, and optional PR metadata for prompt rendering and orchestration.
 - SQLite persists workflow snapshots, issue cache, runs, run attempts, sessions, retry queue entries, workspace records, event log entries, leases, and dispatch claims for restart recovery and debugging.
 - Dispatch enforces exact active-state matching, per-state concurrency caps, continuation retries, exponential-backoff retries, and the `Todo` blocker rule.
-- Reconciliation refreshes active issue states every tick, stops non-active or terminal runs, cleans terminal workspaces, and reschedules stalled runs from the last Codex activity timestamp.
+- Reconciliation refreshes issue states every tick, stops non-active or terminal runs, cleans terminal workspaces for running and retrying issues, and reschedules stalled runs from the last Codex activity timestamp.
 - Codex app-server sessions now support streamed multi-turn execution on a shared thread, permissive auto-approval, structured tool-call failures, and the `github_graphql` client-side tool.
-- Runtime state, tracked issue distribution, recent events, lease snapshots, token totals, and latest rate-limit payloads are available through the HTTP API and are derived from persisted orchestrator state.
+- Runtime state, tracked issue distribution, recent events, lease snapshots, token totals, and latest rate-limit payloads are available through the HTTP API and are derived from persisted orchestrator state. Token totals advance only from absolute Codex usage snapshots, not ordinary per-event `usage` maps.
 
 ## Build and Test
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -105,9 +105,10 @@ Symphony exposes these HTTP endpoints:
 - `POST /api/v1/refresh`: queue an immediate best-effort poll/reconcile cycle
 
 The state and issue endpoints are derived from persisted orchestrator state in SQLite rather than ad hoc in-memory caches.
-Dashboard and `/api/v1/state` token totals are derived from absolute Codex usage snapshots such as `thread/tokenUsage/updated` and `total_token_usage`. Delta-only payloads like `last_token_usage` are ignored to avoid double-counting, so totals only advance when Codex emits a new absolute snapshot.
+Dashboard and `/api/v1/state` token totals are derived from absolute Codex usage snapshots such as `thread/tokenUsage/updated` and `total_token_usage`. Delta-only payloads like `last_token_usage`, and generic `usage` maps on ordinary notifications or turn events, are ignored to avoid double-counting, so totals only advance when Codex emits a new absolute snapshot.
 For human-readable dashboard surfaces, fallback-only `other_message` protocol entries are suppressed when Codex did not emit a useful message; the durable SQLite event log remains available for deeper debugging.
-Tracked issue summaries refresh cached GitHub states for previously seen issues, so the dashboard and `/api/v1/state` continue showing `Closed` counts after issues leave the active set.
+Tracked issue summaries refresh cached GitHub states for previously seen issues, so the dashboard and `/api/v1/state` continue showing `Closed` counts after issues leave the active set. When a tracked retrying issue becomes terminal, Symphony releases its retry reservation and runs the same terminal workspace cleanup used for closed running issues and startup sweeps.
+Per-issue worktree branch creation does not configure upstream tracking, and shared-clone Git mutations are serialized inside the host process to avoid `.git/config` lock contention while several issues start at once.
 On large desktop layouts, the right-hand issue detail rail stays pinned and scrolls independently so long issue detail content does not hide instance health or rate-limit cards.
 The dashboard shell uses the full viewport width on large screens instead of staying capped inside a centered content column.
 Retry queue surfaces show time until the next attempt, and any overdue retry is shown as ready now instead of appearing to be scheduled in the past.

--- a/src/Symphony.Host/Services/OrchestrationTickService.Dispatch.cs
+++ b/src/Symphony.Host/Services/OrchestrationTickService.Dispatch.cs
@@ -166,6 +166,10 @@ public sealed partial class OrchestrationTickService
             run.CompletedAtUtc = null;
             run.RequestedStopReason = null;
             run.CleanupWorkspaceOnStop = false;
+            run.SessionId = null;
+            run.LastReportedInputTokens = 0;
+            run.LastReportedOutputTokens = 0;
+            run.LastReportedTotalTokens = 0;
         }
 
         var runAttempt = new RunAttemptEntity

--- a/src/Symphony.Host/Services/OrchestrationTickService.Persistence.cs
+++ b/src/Symphony.Host/Services/OrchestrationTickService.Persistence.cs
@@ -137,6 +137,7 @@ public sealed partial class OrchestrationTickService
     private async Task RefreshTrackedIssueCacheStatesAsync(
         WorkflowDefinition workflowDefinition,
         string apiKey,
+        string instanceId,
         CancellationToken cancellationToken)
     {
         var cachedIssues = await dbContext.IssueCache.ToListAsync(cancellationToken);
@@ -167,20 +168,138 @@ public sealed partial class OrchestrationTickService
                 continue;
             }
 
-            if (string.Equals(cachedIssue.State, refreshedState.State, StringComparison.OrdinalIgnoreCase))
+            var isTerminal = MatchesTerminalState(
+                refreshedState.State,
+                workflowDefinition.Runtime.Tracker.TerminalStates);
+
+            if (!string.Equals(cachedIssue.State, refreshedState.State, StringComparison.OrdinalIgnoreCase))
             {
-                continue;
+                cachedIssue.State = refreshedState.State;
+                cachedIssue.CachedAtUtc = refreshedAtUtc;
+                hasChanges = true;
             }
 
-            cachedIssue.State = refreshedState.State;
-            cachedIssue.CachedAtUtc = refreshedAtUtc;
-            hasChanges = true;
+            if (isTerminal)
+            {
+                await CleanupTerminalTrackedIssueWorkspaceAsync(
+                    cachedIssue,
+                    workflowDefinition,
+                    instanceId,
+                    cancellationToken);
+            }
         }
 
         if (hasChanges)
         {
             await dbContext.SaveChangesAsync(cancellationToken);
         }
+    }
+
+    private async Task CleanupTerminalTrackedIssueWorkspaceAsync(
+        IssueCacheEntity cachedIssue,
+        WorkflowDefinition workflowDefinition,
+        string instanceId,
+        CancellationToken cancellationToken)
+    {
+        var hasRunningRun = await dbContext.Runs.AnyAsync(
+            run => run.IssueId == cachedIssue.IssueId && run.Status == RunStatusNames.Running,
+            cancellationToken);
+        if (hasRunningRun)
+        {
+            return;
+        }
+
+        var workspaceRecord = await dbContext.WorkspaceRecords.SingleOrDefaultAsync(
+            record => record.IssueId == cachedIssue.IssueId,
+            cancellationToken);
+
+        var releasedRetryState = await ReleaseTerminalRetryStateAsync(cachedIssue, instanceId, cancellationToken);
+        if (workspaceRecord is null && !releasedRetryState)
+        {
+            return;
+        }
+
+        if (workspaceRecord is not null &&
+            workspaceRecord.LastCleanedAtUtc.HasValue &&
+            string.Equals(workspaceRecord.LastCleanupReason, RunStopReasons.Terminal, StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
+
+        try
+        {
+            var cleanupResult = await workspaceManager.CleanupIssueWorkspaceAsync(
+                new WorkspaceCleanupRequest(
+                    cachedIssue.Identifier,
+                    workflowDefinition.Runtime.Workspace.Root,
+                    workflowDefinition.Runtime.Workspace.SharedClonePath,
+                    workflowDefinition.Runtime.Workspace.WorktreesRoot,
+                    workflowDefinition.Runtime.Hooks.BeforeRemove,
+                    workflowDefinition.Runtime.Hooks.TimeoutMs),
+                cancellationToken);
+
+            if (workspaceRecord is not null && (!cleanupResult.Existed || cleanupResult.RemovedNow))
+            {
+                workspaceRecord.LastCleanedAtUtc = timeProvider.GetUtcNow();
+                workspaceRecord.LastCleanupReason = RunStopReasons.Terminal;
+                await dbContext.SaveChangesAsync(cancellationToken);
+            }
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Tracked terminal cleanup failed for issue {IssueIdentifier}.", cachedIssue.Identifier);
+        }
+    }
+
+    private async Task<bool> ReleaseTerminalRetryStateAsync(
+        IssueCacheEntity cachedIssue,
+        string instanceId,
+        CancellationToken cancellationToken)
+    {
+        var nowUtc = timeProvider.GetUtcNow();
+        var retryingRuns = await dbContext.Runs
+            .Where(run => run.IssueId == cachedIssue.IssueId && run.Status == RunStatusNames.Retrying)
+            .ToListAsync(cancellationToken);
+
+        foreach (var run in retryingRuns)
+        {
+            run.Status = RunStatusNames.CanceledByReconciliation;
+            run.CompletedAtUtc = nowUtc;
+            run.RequestedStopReason = null;
+            run.CleanupWorkspaceOnStop = false;
+            run.LastEvent = "terminal_state_observed";
+            run.LastMessage = RunStopReasons.Terminal;
+            run.LastEventAtUtc = nowUtc;
+        }
+
+        var retryEntries = await dbContext.RetryQueue
+            .Where(entry => entry.IssueId == cachedIssue.IssueId)
+            .ToListAsync(cancellationToken);
+        if (retryEntries.Count > 0)
+        {
+            dbContext.RetryQueue.RemoveRange(retryEntries);
+        }
+
+        if (retryingRuns.Count > 0 || retryEntries.Count > 0)
+        {
+            await coordinationStore.ReleaseIssueClaimAsync(
+                cachedIssue.IssueId,
+                instanceId,
+                RunStatusNames.CanceledByReconciliation,
+                cancellationToken);
+        }
+
+        if (retryingRuns.Count > 0 || retryEntries.Count > 0)
+        {
+            await dbContext.SaveChangesAsync(cancellationToken);
+            return true;
+        }
+
+        return false;
     }
 
     private async Task<IReadOnlyList<IssueStateSnapshot>?> TryFetchIssueStatesByIdsAsync(

--- a/src/Symphony.Host/Services/OrchestrationTickService.Reconciliation.cs
+++ b/src/Symphony.Host/Services/OrchestrationTickService.Reconciliation.cs
@@ -219,6 +219,8 @@ public sealed partial class OrchestrationTickService
         run.LastMessage = stopReason;
         run.LastEventAtUtc = timeProvider.GetUtcNow();
 
+        await dbContext.SaveChangesAsync(cancellationToken);
+
         var stopRequested = await issueExecutionCoordinator.TryStopAsync(run.IssueId, cancellationToken);
         if (stopRequested)
         {

--- a/src/Symphony.Host/Services/OrchestrationTickService.cs
+++ b/src/Symphony.Host/Services/OrchestrationTickService.cs
@@ -128,7 +128,7 @@ public sealed partial class OrchestrationTickService
             await ReconcileRunningIssuesAsync(workflowDefinition, apiKey, preflightError, instanceId, cancellationToken);
             if (preflightError is null && !string.IsNullOrWhiteSpace(apiKey))
             {
-                await RefreshTrackedIssueCacheStatesAsync(workflowDefinition, apiKey, cancellationToken);
+                await RefreshTrackedIssueCacheStatesAsync(workflowDefinition, apiKey, instanceId, cancellationToken);
             }
 
             if (preflightError is not null || string.IsNullOrWhiteSpace(apiKey))

--- a/src/Symphony.Infrastructure.Agent.Codex/CodexAgentRunner.cs
+++ b/src/Symphony.Infrastructure.Agent.Codex/CodexAgentRunner.cs
@@ -1085,13 +1085,14 @@ public sealed partial class CodexAgentRunner(
 
     private static bool TryExtractUsage(JsonElement root, string eventName, out UsageSnapshot? usage)
     {
-        if (IsAbsoluteTokenUsageEvent(eventName) &&
+        var isAbsoluteTokenUsageEvent = IsAbsoluteTokenUsageEvent(eventName);
+        if (isAbsoluteTokenUsageEvent &&
             TryParseUsageObject(GetMessagePayload(root), out usage))
         {
             return true;
         }
 
-        foreach (var propertyName in new[] { "total_token_usage", "totalTokenUsage", "token_usage", "tokenUsage", "usage" })
+        foreach (var propertyName in new[] { "total_token_usage", "totalTokenUsage", "token_usage", "tokenUsage" })
         {
             if (!TryFindPropertyRecursive(root, propertyName, out var usageElement))
             {
@@ -1102,6 +1103,13 @@ public sealed partial class CodexAgentRunner(
             {
                 return true;
             }
+        }
+
+        if (isAbsoluteTokenUsageEvent &&
+            TryFindPropertyRecursive(root, "usage", out var genericUsageElement) &&
+            TryParseUsageObject(genericUsageElement, out usage))
+        {
+            return true;
         }
 
         usage = null;

--- a/src/Symphony.Infrastructure.Workspaces/GitWorktreeWorkspaceManager.cs
+++ b/src/Symphony.Infrastructure.Workspaces/GitWorktreeWorkspaceManager.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Text;
 using Microsoft.Extensions.Logging;
@@ -10,6 +11,8 @@ public sealed class GitWorktreeWorkspaceManager(
     IWorkspaceHookRunner workspaceHookRunner,
     ILogger<GitWorktreeWorkspaceManager> logger) : IWorkspaceManager
 {
+    private static readonly ConcurrentDictionary<string, SemaphoreSlim> SharedCloneLocks = new(StringComparer.OrdinalIgnoreCase);
+
     public async Task<WorkspacePreparationResult> PrepareIssueWorkspaceAsync(
         WorkspacePreparationRequest request,
         CancellationToken cancellationToken = default)
@@ -44,42 +47,51 @@ public sealed class GitWorktreeWorkspaceManager(
         Directory.CreateDirectory(rootPath);
         Directory.CreateDirectory(worktreesRootPath);
 
-        await EnsureSharedCloneAsync(sharedClonePath, request.RemoteRepositoryUrl, cancellationToken);
-        await EnsureLatestFromOriginAsync(sharedClonePath, request.BaseBranch, cancellationToken);
-
-        if (Directory.Exists(worktreePath))
-        {
-            logger.LogInformation(
-                "Reusing existing workspace {WorkspacePath} for issue {IssueIdentifier}.",
-                worktreePath,
-                request.IssueIdentifier);
-
-            return new WorkspacePreparationResult(worktreePath, branchName, CreatedNow: false);
-        }
-
+        var sharedCloneLock = GetSharedCloneLock(sharedClonePath);
+        await sharedCloneLock.WaitAsync(cancellationToken);
         try
         {
-            var hasLocalBranch = await HasLocalBranchAsync(sharedClonePath, branchName, cancellationToken);
-            if (hasLocalBranch)
-            {
-                await RunGitAsync(sharedClonePath, ["worktree", "add", worktreePath, branchName], cancellationToken);
-            }
-            else
-            {
-                await RunGitAsync(
-                    sharedClonePath,
-                    ["worktree", "add", "-b", branchName, worktreePath, $"origin/{request.BaseBranch}"],
-                    cancellationToken);
-            }
-        }
-        catch
-        {
+            await EnsureSharedCloneAsync(sharedClonePath, request.RemoteRepositoryUrl, cancellationToken);
+            await EnsureLatestFromOriginAsync(sharedClonePath, request.BaseBranch, cancellationToken);
+
             if (Directory.Exists(worktreePath))
             {
-                _ = await RemoveWorktreePathAsync(sharedClonePath, worktreePath, CancellationToken.None);
+                logger.LogInformation(
+                    "Reusing existing workspace {WorkspacePath} for issue {IssueIdentifier}.",
+                    worktreePath,
+                    request.IssueIdentifier);
+
+                return new WorkspacePreparationResult(worktreePath, branchName, CreatedNow: false);
             }
 
-            throw;
+            try
+            {
+                var hasLocalBranch = await HasLocalBranchAsync(sharedClonePath, branchName, cancellationToken);
+                if (hasLocalBranch)
+                {
+                    await RunGitAsync(sharedClonePath, ["worktree", "add", worktreePath, branchName], cancellationToken);
+                }
+                else
+                {
+                    await RunGitAsync(
+                        sharedClonePath,
+                        ["worktree", "add", "--no-track", "-b", branchName, worktreePath, $"origin/{request.BaseBranch}"],
+                        cancellationToken);
+                }
+            }
+            catch
+            {
+                if (Directory.Exists(worktreePath))
+                {
+                    _ = await RemoveWorktreePathAsync(sharedClonePath, worktreePath, CancellationToken.None);
+                }
+
+                throw;
+            }
+        }
+        finally
+        {
+            sharedCloneLock.Release();
         }
 
         logger.LogInformation(
@@ -156,7 +168,18 @@ public sealed class GitWorktreeWorkspaceManager(
             }
         }
 
-        var removedNow = await RemoveWorktreePathAsync(sharedClonePath, worktreePath, cancellationToken);
+        var sharedCloneLock = GetSharedCloneLock(sharedClonePath);
+        await sharedCloneLock.WaitAsync(cancellationToken);
+        bool removedNow;
+        try
+        {
+            removedNow = await RemoveWorktreePathAsync(sharedClonePath, worktreePath, cancellationToken);
+        }
+        finally
+        {
+            sharedCloneLock.Release();
+        }
+
         if (removedNow)
         {
             logger.LogInformation(
@@ -188,7 +211,7 @@ public sealed class GitWorktreeWorkspaceManager(
         var gitDirectoryPath = Path.Combine(sharedClonePath, ".git");
         if (Directory.Exists(gitDirectoryPath))
         {
-            await RunGitAsync(sharedClonePath, ["remote", "set-url", "origin", remoteRepositoryUrl], cancellationToken);
+            await EnsureRemoteUrlAsync(sharedClonePath, remoteRepositoryUrl, cancellationToken);
             return;
         }
 
@@ -202,6 +225,25 @@ public sealed class GitWorktreeWorkspaceManager(
             workingDirectory: null,
             ["clone", "--no-checkout", remoteRepositoryUrl, sharedClonePath],
             cancellationToken);
+    }
+
+    private async Task EnsureRemoteUrlAsync(
+        string sharedClonePath,
+        string remoteRepositoryUrl,
+        CancellationToken cancellationToken)
+    {
+        var currentRemote = await RunGitAsync(
+            sharedClonePath,
+            ["remote", "get-url", "origin"],
+            cancellationToken,
+            throwOnNonZeroExitCode: false);
+        if (currentRemote.ExitCode == 0 &&
+            currentRemote.Stdout.Trim().Equals(remoteRepositoryUrl, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        await RunGitAsync(sharedClonePath, ["remote", "set-url", "origin", remoteRepositoryUrl], cancellationToken);
     }
 
     private async Task EnsureLatestFromOriginAsync(string sharedClonePath, string baseBranch, CancellationToken cancellationToken)
@@ -320,6 +362,7 @@ public sealed class GitWorktreeWorkspaceManager(
         process.BeginOutputReadLine();
         process.BeginErrorReadLine();
         await process.WaitForExitAsync(cancellationToken);
+        process.WaitForExit();
 
         var result = new GitResult(process.ExitCode, stdout.ToString(), stderr.ToString());
         if (throwOnNonZeroExitCode && result.ExitCode != 0)
@@ -332,6 +375,9 @@ public sealed class GitWorktreeWorkspaceManager(
     }
 
     private sealed record GitResult(int ExitCode, string Stdout, string Stderr);
+
+    private static SemaphoreSlim GetSharedCloneLock(string sharedClonePath) =>
+        SharedCloneLocks.GetOrAdd(sharedClonePath, _ => new SemaphoreSlim(1, 1));
 
     private static void EnsureDirectoryPathAvailable(string path, string logicalName)
     {

--- a/tests/Symphony.Integration.Tests/CodexAgentRunnerTests.cs
+++ b/tests/Symphony.Integration.Tests/CodexAgentRunnerTests.cs
@@ -132,6 +132,49 @@ public sealed class CodexAgentRunnerTests
     }
 
     [Fact]
+    public void CreateProtocolUpdate_ShouldIgnoreGenericUsageOnOrdinaryEvents()
+    {
+        var update = CreateProtocolUpdate("""
+            {
+              "method": "turn/completed",
+              "params": {
+                "message": "done",
+                "usage": {
+                  "input_tokens": 11,
+                  "output_tokens": 7,
+                  "total_tokens": 18
+                }
+              }
+            }
+            """);
+
+        Assert.Null(update.InputTokens);
+        Assert.Null(update.OutputTokens);
+        Assert.Null(update.TotalTokens);
+    }
+
+    [Fact]
+    public void CreateProtocolUpdate_ShouldReadGenericUsageFromThreadTokenUsageUpdatedPayloads()
+    {
+        var update = CreateProtocolUpdate("""
+            {
+              "method": "thread/tokenUsage/updated",
+              "params": {
+                "usage": {
+                  "input_tokens": 11,
+                  "output_tokens": 7,
+                  "total_tokens": 18
+                }
+              }
+            }
+            """);
+
+        Assert.Equal(11, update.InputTokens);
+        Assert.Equal(7, update.OutputTokens);
+        Assert.Equal(18, update.TotalTokens);
+    }
+
+    [Fact]
     public void CreateProtocolUpdate_ShouldClampDerivedTotalTokensToIntMaxValue()
     {
         var update = CreateProtocolUpdate($$"""

--- a/tests/Symphony.Integration.Tests/OrchestrationTickServiceTests.cs
+++ b/tests/Symphony.Integration.Tests/OrchestrationTickServiceTests.cs
@@ -114,6 +114,30 @@ public sealed class OrchestrationTickServiceTests
     }
 
     [Fact]
+    public async Task RunTickAsync_ShouldPersistTerminalStopBeforeCancelingLiveRun()
+    {
+        var coordinator = new FakeIssueExecutionCoordinator(
+            FakeDispatchOutcome.LeaveRunning,
+            observeStopStateWithFreshContext: true);
+
+        await using var harness = await TestHarness.CreateAsync(
+            BuildWorkflowDefinition(maxConcurrentAgents: 1),
+            tracker: new FakeTrackerClient([], issueStatesById: new Dictionary<string, string>
+            {
+                ["issue-1"] = "Closed"
+            }),
+            coordinator);
+
+        await harness.InsertRunningRunAsync("issue-1", "#1", "Open", "instance-1");
+
+        await harness.Service.RunTickAsync(CancellationToken.None);
+
+        Assert.NotNull(coordinator.ObservedStopState);
+        Assert.Equal(RunStopReasons.Terminal, coordinator.ObservedStopState.Value.RequestedStopReason);
+        Assert.True(coordinator.ObservedStopState.Value.CleanupWorkspaceOnStop);
+    }
+
+    [Fact]
     public async Task RunTickAsync_ShouldRefreshTrackedIssueCacheStateForClosedIssues()
     {
         await using var harness = await TestHarness.CreateAsync(
@@ -132,6 +156,62 @@ public sealed class OrchestrationTickServiceTests
         var cachedIssue = await harness.DbContext.IssueCache.SingleAsync();
         Assert.Equal("Closed", cachedIssue.State);
         Assert.True(cachedIssue.CachedAtUtc > initialCachedAtUtc);
+    }
+
+    [Fact]
+    public async Task RunTickAsync_ShouldCleanupRetryWorkspaceWhenTrackedIssueBecomesClosed()
+    {
+        await using var harness = await TestHarness.CreateAsync(
+            BuildWorkflowDefinition(maxConcurrentAgents: 1),
+            tracker: new FakeTrackerClient([], issueStatesById: new Dictionary<string, string>
+            {
+                ["issue-1"] = "Closed"
+            }),
+            coordinator: new FakeIssueExecutionCoordinator(FakeDispatchOutcome.LeaveRunning));
+
+        await harness.InsertIssueCacheAsync("issue-1", "#1", "Open", DateTimeOffset.UtcNow.AddMinutes(-5));
+        await harness.InsertRetryingRunAsync("issue-1", "#1", "Open", "instance-1");
+
+        await harness.Service.RunTickAsync(CancellationToken.None);
+
+        var cleanupRequest = Assert.Single(harness.WorkspaceManager.CleanupRequests);
+        Assert.Equal("#1", cleanupRequest.IssueIdentifier);
+        Assert.Empty(await harness.DbContext.RetryQueue.ToListAsync());
+        Assert.Equal(RunStatusNames.CanceledByReconciliation, (await harness.DbContext.Runs.SingleAsync()).Status);
+        Assert.Equal(RunStatusNames.CanceledByReconciliation, (await harness.DbContext.DispatchClaims.SingleAsync()).Status);
+        Assert.NotNull((await harness.DbContext.WorkspaceRecords.SingleAsync()).LastCleanedAtUtc);
+    }
+
+    [Fact]
+    public async Task RunTickAsync_ShouldResetLastReportedTokenTotalsWhenRetryStartsNewAttempt()
+    {
+        await using var harness = await TestHarness.CreateAsync(
+            BuildWorkflowDefinition(maxConcurrentAgents: 1),
+            tracker: new FakeTrackerClient([BuildIssue("issue-1", "#1", "Open", null)]),
+            coordinator: new FakeIssueExecutionCoordinator(FakeDispatchOutcome.LeaveRunning));
+
+        await harness.InsertRetryingRunAsync(
+            "issue-1",
+            "#1",
+            "Open",
+            "instance-1",
+            inputTokens: 100,
+            outputTokens: 50,
+            totalTokens: 150,
+            lastReportedInputTokens: 100,
+            lastReportedOutputTokens: 50,
+            lastReportedTotalTokens: 150);
+
+        await harness.Service.RunTickAsync(CancellationToken.None);
+
+        var run = await harness.DbContext.Runs.SingleAsync();
+        Assert.Equal(RunStatusNames.Running, run.Status);
+        Assert.Equal(100, run.InputTokens);
+        Assert.Equal(50, run.OutputTokens);
+        Assert.Equal(150, run.TotalTokens);
+        Assert.Equal(0, run.LastReportedInputTokens);
+        Assert.Equal(0, run.LastReportedOutputTokens);
+        Assert.Equal(0, run.LastReportedTotalTokens);
     }
 
     [Fact]
@@ -315,7 +395,7 @@ public sealed class OrchestrationTickServiceTests
             await dbContext.Database.EnsureCreatedAsync();
 
             var workspaceManager = new FakeWorkspaceManager();
-            coordinator.Attach(dbContext);
+            coordinator.Attach(dbContext, dbPath);
 
             var service = new OrchestrationTickService(
                 new FakeWorkflowDefinitionProvider(workflowDefinition),
@@ -415,6 +495,72 @@ public sealed class OrchestrationTickServiceTests
             await DbContext.SaveChangesAsync();
         }
 
+        public async Task InsertRetryingRunAsync(
+            string issueId,
+            string identifier,
+            string state,
+            string instanceId,
+            int inputTokens = 0,
+            int outputTokens = 0,
+            int totalTokens = 0,
+            int lastReportedInputTokens = 0,
+            int lastReportedOutputTokens = 0,
+            int lastReportedTotalTokens = 0)
+        {
+            var nowUtc = DateTimeOffset.UtcNow;
+            var run = new RunEntity
+            {
+                Id = Guid.NewGuid().ToString("N"),
+                IssueId = issueId,
+                IssueIdentifier = identifier,
+                OwnerInstanceId = instanceId,
+                Status = RunStatusNames.Retrying,
+                State = state,
+                CurrentRetryAttempt = 1,
+                StartedAtUtc = nowUtc.AddMinutes(-1),
+                InputTokens = inputTokens,
+                OutputTokens = outputTokens,
+                TotalTokens = totalTokens,
+                LastReportedInputTokens = lastReportedInputTokens,
+                LastReportedOutputTokens = lastReportedOutputTokens,
+                LastReportedTotalTokens = lastReportedTotalTokens
+            };
+
+            DbContext.Runs.Add(run);
+            DbContext.RetryQueue.Add(new RetryQueueEntity
+            {
+                IssueId = issueId,
+                IssueIdentifier = identifier,
+                RunId = run.Id,
+                OwnerInstanceId = instanceId,
+                Attempt = 1,
+                DueAtUtc = nowUtc.AddSeconds(-1),
+                DelayType = RetryDelayTypes.Continuation,
+                MaxBackoffMs = 300_000,
+                CreatedAtUtc = nowUtc.AddMinutes(-1),
+                UpdatedAtUtc = nowUtc.AddMinutes(-1)
+            });
+            DbContext.DispatchClaims.Add(new DispatchClaimEntity
+            {
+                IssueId = issueId,
+                IssueIdentifier = identifier,
+                ClaimedByInstanceId = instanceId,
+                ClaimedAtUtc = nowUtc.AddMinutes(-1),
+                UpdatedAtUtc = nowUtc.AddMinutes(-1),
+                Status = "active"
+            });
+            DbContext.WorkspaceRecords.Add(new WorkspaceRecordEntity
+            {
+                IssueId = issueId,
+                IssueIdentifier = identifier,
+                WorkspacePath = $"C:\\tmp\\{identifier}",
+                BranchName = $"symphony/{identifier}",
+                LastPreparedAtUtc = nowUtc.AddMinutes(-1)
+            });
+
+            await DbContext.SaveChangesAsync();
+        }
+
         public async ValueTask DisposeAsync()
         {
             await DbContext.DisposeAsync();
@@ -505,16 +651,22 @@ public sealed class OrchestrationTickServiceTests
         Failure
     }
 
-    private sealed class FakeIssueExecutionCoordinator(FakeDispatchOutcome outcome, bool stopReturnsFalse = false) : IIssueExecutionCoordinator
+    private sealed class FakeIssueExecutionCoordinator(
+        FakeDispatchOutcome outcome,
+        bool stopReturnsFalse = false,
+        bool observeStopStateWithFreshContext = false) : IIssueExecutionCoordinator
     {
         private SymphonyDbContext? dbContext;
+        private string? dbPath;
 
         public List<IssueExecutionRequest> StartRequests { get; } = [];
         public List<string> StopRequests { get; } = [];
+        public (string? RequestedStopReason, bool CleanupWorkspaceOnStop)? ObservedStopState { get; private set; }
 
-        public void Attach(SymphonyDbContext dbContext)
+        public void Attach(SymphonyDbContext dbContext, string dbPath)
         {
             this.dbContext = dbContext;
+            this.dbPath = dbPath;
         }
 
         public async Task<bool> TryStartAsync(IssueExecutionRequest request, CancellationToken cancellationToken = default)
@@ -577,10 +729,23 @@ public sealed class OrchestrationTickServiceTests
             return true;
         }
 
-        public Task<bool> TryStopAsync(string issueId, CancellationToken cancellationToken = default)
+        public async Task<bool> TryStopAsync(string issueId, CancellationToken cancellationToken = default)
         {
             StopRequests.Add(issueId);
-            return Task.FromResult(!stopReturnsFalse);
+
+            if (observeStopStateWithFreshContext && dbPath is not null)
+            {
+                var options = new DbContextOptionsBuilder<SymphonyDbContext>()
+                    .UseSqlite($"Data Source={dbPath}")
+                    .Options;
+                await using var freshDbContext = new SymphonyDbContext(options);
+                var run = await freshDbContext.Runs.SingleAsync(
+                    runEntity => runEntity.IssueId == issueId,
+                    cancellationToken);
+                ObservedStopState = (run.RequestedStopReason, run.CleanupWorkspaceOnStop);
+            }
+
+            return !stopReturnsFalse;
         }
     }
 }

--- a/tests/Symphony.Integration.Tests/WorkspaceManagerTests.cs
+++ b/tests/Symphony.Integration.Tests/WorkspaceManagerTests.cs
@@ -54,6 +54,13 @@ public sealed class WorkspaceManagerTests
             var currentBranch = await RunGitAsync(first.WorkspacePath, ["rev-parse", "--abbrev-ref", "HEAD"]);
             Assert.Equal("symphony/101", currentBranch.Stdout.Trim());
 
+            var upstreamRemote = await RunGitAsync(
+                sharedClonePath,
+                ["config", "--get", "branch.symphony/101.remote"],
+                throwOnNonZeroExitCode: false);
+            Assert.Equal(1, upstreamRemote.ExitCode);
+            Assert.True(string.IsNullOrWhiteSpace(upstreamRemote.Stdout));
+
             var second = await manager.PrepareIssueWorkspaceAsync(request);
             Assert.False(second.CreatedNow);
         }
@@ -172,7 +179,10 @@ public sealed class WorkspaceManagerTests
         }
     }
 
-    private static async Task<GitCommandResult> RunGitAsync(string workingDirectory, IReadOnlyList<string> args)
+    private static async Task<GitCommandResult> RunGitAsync(
+        string workingDirectory,
+        IReadOnlyList<string> args,
+        bool throwOnNonZeroExitCode = true)
     {
         var info = new ProcessStartInfo
         {
@@ -199,16 +209,16 @@ public sealed class WorkspaceManagerTests
         var stderr = await process.StandardError.ReadToEndAsync();
         await process.WaitForExitAsync();
 
-        if (process.ExitCode != 0)
+        if (throwOnNonZeroExitCode && process.ExitCode != 0)
         {
             throw new InvalidOperationException(
                 $"Git failed (exit {process.ExitCode}) with args '{string.Join(' ', args)}'{Environment.NewLine}{stderr}");
         }
 
-        return new GitCommandResult(stdout, stderr);
+        return new GitCommandResult(process.ExitCode, stdout, stderr);
     }
 
-    private sealed record GitCommandResult(string Stdout, string Stderr);
+    private sealed record GitCommandResult(int ExitCode, string Stdout, string Stderr);
 
     private sealed class NoOpWorkspaceHookRunner : IWorkspaceHookRunner
     {


### PR DESCRIPTION
## Spec References

- `SPEC.md` Section 8.5: terminal tracker state stops running workers and cleans the workspace.
- `SPEC.md` Section 8.6: startup and terminal workspace cleanup semantics.
- `SPEC.md` Section 13.5: token accounting must prefer absolute totals, ignore delta/generic payloads, and track deltas from last reported totals.
- `SPEC.md` Section 15.1/15.2: workspace containment and subprocess safety remain mandatory.
- `SPEC.md` Section 17.2, 17.4, 17.5, and 17.6: conformance coverage for workspace cleanup, reconciliation, protocol usage extraction, and token/rate-limit observability.

## Summary

This change tightens terminal cleanup, token accounting, and Git worktree preparation reliability for Symphony's v1 orchestrator.

### Terminal Worktree Cleanup

- Persists terminal stop intent before canceling live issue workers, so the runner can reliably observe `RunStopReasons.Terminal` and the `CleanupWorkspaceOnStop` flag.
- Cleans worktrees for tracked retrying issues when GitHub reports the issue has moved to a configured terminal state such as `Closed`.
- Releases retry queue entries and active dispatch claims for retrying issues that become terminal.
- Records terminal cleanup metadata on workspace records when cleanup succeeds or the workspace is already absent.

### Token Reporting

- Stops treating ordinary per-event `usage` maps as cumulative token totals.
- Continues accepting absolute usage payloads such as `thread/tokenUsage/updated`, `total_token_usage`, `totalTokenUsage`, `token_usage`, and `tokenUsage`.
- Still accepts a nested `usage` map when the event itself is an absolute token usage update.
- Resets `LastReported*Tokens` when a retry run starts a fresh agent attempt so new absolute session totals are counted correctly without losing the aggregate run totals.

### Git Worktree Config Lock Fix

- Creates new per-issue worktree branches with `git worktree add --no-track -b ...` so Git does not attempt to write upstream branch configuration.
- Serializes shared-clone Git mutations inside the host process to reduce `.git/config` and worktree metadata contention when multiple issues dispatch concurrently.
- Avoids unnecessary `git remote set-url origin ...` calls when the shared clone already points at the configured remote.
- Flushes Git redirected output before checking command results.

### Documentation

- Updates `README.md` to describe retrying terminal workspace cleanup and absolute-only token totals.
- Updates `docs/UserGuide.md` to document terminal retry cleanup, token accounting behavior, and upstream-free worktree branch creation.

## Tests

- `dotnet test tests/Symphony.Integration.Tests/Symphony.Integration.Tests.csproj --filter "WorkspaceManagerTests|OrchestrationTickServiceTests|CodexAgentRunnerTests"`
- `dotnet test`

Full suite result: 13 core tests passed, 119 integration tests passed, 1 real GitHub integration test skipped because it is gated by opt-in credentials.

## Notes

- The pre-existing untracked `.claude/` directory was intentionally not staged.
- No migrations were required.