### PR TITLE
[codex] Update Codex CLI and token accounting

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ COPY . .
 RUN dotnet publish src/Symphony.Host/Symphony.Host.csproj -c Release -o /app/publish /p:UseAppHost=false
 
 FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS runtime
-ARG CODEX_NPM_VERSION=0.114.0
+ARG CODEX_NPM_VERSION=0.135.0
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends bash ca-certificates curl git nodejs npm openssh-client \

--- a/deploy/container/docker-compose.yml
+++ b/deploy/container/docker-compose.yml
@@ -4,7 +4,7 @@ services:
       context: ../..
       dockerfile: Dockerfile
       args:
-        CODEX_NPM_VERSION: ${CODEX_NPM_VERSION:-0.114.0}
+        CODEX_NPM_VERSION: ${CODEX_NPM_VERSION:-0.135.0}
     image: ${SYMPHONY_IMAGE:-symphony:dev}
     restart: unless-stopped
     ports:

--- a/src/Symphony.Core/Models/AgentRunUpdate.cs
+++ b/src/Symphony.Core/Models/AgentRunUpdate.cs
@@ -10,6 +10,7 @@ public sealed record AgentRunUpdate(
     int? InputTokens = null,
     int? OutputTokens = null,
     int? TotalTokens = null,
+    bool TokenUsageIsDelta = false,
     string? RateLimitsJson = null,
     string? DataJson = null)
 {

--- a/src/Symphony.Host/Services/IssueExecutionCoordinator.cs
+++ b/src/Symphony.Host/Services/IssueExecutionCoordinator.cs
@@ -642,16 +642,41 @@ public sealed class IssueExecutionCoordinator(
 
     private static void ApplyTokenTotals(RunEntity run, AgentRunUpdate update)
     {
-        (run.InputTokens, run.LastReportedInputTokens) = AccumulateAbsoluteTotal(run.InputTokens, run.LastReportedInputTokens, update.InputTokens);
-        (run.OutputTokens, run.LastReportedOutputTokens) = AccumulateAbsoluteTotal(run.OutputTokens, run.LastReportedOutputTokens, update.OutputTokens);
-        (run.TotalTokens, run.LastReportedTotalTokens) = AccumulateAbsoluteTotal(run.TotalTokens, run.LastReportedTotalTokens, update.TotalTokens);
+        (run.InputTokens, run.LastReportedInputTokens) = AccumulateTokenTotal(run.InputTokens, run.LastReportedInputTokens, update.InputTokens, update.TokenUsageIsDelta);
+        (run.OutputTokens, run.LastReportedOutputTokens) = AccumulateTokenTotal(run.OutputTokens, run.LastReportedOutputTokens, update.OutputTokens, update.TokenUsageIsDelta);
+        (run.TotalTokens, run.LastReportedTotalTokens) = AccumulateTokenTotal(run.TotalTokens, run.LastReportedTotalTokens, update.TotalTokens, update.TokenUsageIsDelta);
     }
 
     private static void ApplyTokenTotals(SessionEntity session, AgentRunUpdate update)
     {
-        (session.CodexInputTokens, session.LastReportedInputTokens) = AccumulateAbsoluteTotal(session.CodexInputTokens, session.LastReportedInputTokens, update.InputTokens);
-        (session.CodexOutputTokens, session.LastReportedOutputTokens) = AccumulateAbsoluteTotal(session.CodexOutputTokens, session.LastReportedOutputTokens, update.OutputTokens);
-        (session.CodexTotalTokens, session.LastReportedTotalTokens) = AccumulateAbsoluteTotal(session.CodexTotalTokens, session.LastReportedTotalTokens, update.TotalTokens);
+        (session.CodexInputTokens, session.LastReportedInputTokens) = AccumulateTokenTotal(session.CodexInputTokens, session.LastReportedInputTokens, update.InputTokens, update.TokenUsageIsDelta);
+        (session.CodexOutputTokens, session.LastReportedOutputTokens) = AccumulateTokenTotal(session.CodexOutputTokens, session.LastReportedOutputTokens, update.OutputTokens, update.TokenUsageIsDelta);
+        (session.CodexTotalTokens, session.LastReportedTotalTokens) = AccumulateTokenTotal(session.CodexTotalTokens, session.LastReportedTotalTokens, update.TotalTokens, update.TokenUsageIsDelta);
+    }
+
+    private static (int AccumulatedTotal, int LastReportedTotal) AccumulateTokenTotal(
+        int accumulatedTotal,
+        int lastReportedTotal,
+        int? nextObservedTotal,
+        bool tokenUsageIsDelta)
+    {
+        return tokenUsageIsDelta
+            ? AccumulateDeltaTotal(accumulatedTotal, lastReportedTotal, nextObservedTotal)
+            : AccumulateAbsoluteTotal(accumulatedTotal, lastReportedTotal, nextObservedTotal);
+    }
+
+    private static (int AccumulatedTotal, int LastReportedTotal) AccumulateDeltaTotal(
+        int accumulatedTotal,
+        int lastReportedTotal,
+        int? nextObservedDelta)
+    {
+        if (!nextObservedDelta.HasValue)
+        {
+            return (accumulatedTotal, lastReportedTotal);
+        }
+
+        var delta = Math.Max(nextObservedDelta.Value, 0);
+        return (accumulatedTotal + delta, lastReportedTotal + delta);
     }
 
     private static (int AccumulatedTotal, int LastReportedTotal) AccumulateAbsoluteTotal(

--- a/src/Symphony.Host/Setup/CodexCliPreflightEvaluator.cs
+++ b/src/Symphony.Host/Setup/CodexCliPreflightEvaluator.cs
@@ -6,7 +6,7 @@ namespace Symphony.Host.Setup;
 
 internal static class CodexCliPreflightEvaluator
 {
-    internal const string ValidatedNpmVersion = "0.114.0";
+    internal const string ValidatedNpmVersion = "0.135.0";
     internal static readonly TimeSpan DefaultProbeTimeout = TimeSpan.FromSeconds(10);
     private const string CodexPackageName = "@openai/codex";
     private const string AuthFileName = "auth.json";

--- a/src/Symphony.Infrastructure.Agent.Codex/CodexAgentRunner.cs
+++ b/src/Symphony.Infrastructure.Agent.Codex/CodexAgentRunner.cs
@@ -1079,6 +1079,7 @@ public sealed partial class CodexAgentRunner(
             InputTokens: usage?.InputTokens,
             OutputTokens: usage?.OutputTokens,
             TotalTokens: usage?.TotalTokens,
+            TokenUsageIsDelta: usage?.IsDelta ?? false,
             RateLimitsJson: SecretRedactor.Redact(rateLimitsJson, knownSecret),
             DataJson: SecretRedactor.Redact(message.GetRawText(), knownSecret));
     }
@@ -1089,6 +1090,7 @@ public sealed partial class CodexAgentRunner(
         if (isAbsoluteTokenUsageEvent &&
             TryParseUsageObject(GetMessagePayload(root), out usage))
         {
+            usage = usage! with { IsDelta = false };
             return true;
         }
 
@@ -1101,6 +1103,7 @@ public sealed partial class CodexAgentRunner(
 
             if (TryParseUsageObject(usageElement, out usage))
             {
+                usage = usage! with { IsDelta = false };
                 return true;
             }
         }
@@ -1109,6 +1112,15 @@ public sealed partial class CodexAgentRunner(
             TryFindPropertyRecursive(root, "usage", out var genericUsageElement) &&
             TryParseUsageObject(genericUsageElement, out usage))
         {
+            usage = usage! with { IsDelta = false };
+            return true;
+        }
+
+        if (IsDeltaTokenUsageEvent(eventName) &&
+            TryFindPropertyRecursive(root, "usage", out var deltaUsageElement) &&
+            TryParseUsageObject(deltaUsageElement, out usage))
+        {
+            usage = usage! with { IsDelta = true };
             return true;
         }
 
@@ -1136,6 +1148,24 @@ public sealed partial class CodexAgentRunner(
         return normalizedEventName.Contains("thread", StringComparison.OrdinalIgnoreCase) &&
                normalizedEventName.Contains("tokenusage", StringComparison.OrdinalIgnoreCase) &&
                normalizedEventName.Contains("updated", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool IsDeltaTokenUsageEvent(string eventName)
+    {
+        if (string.IsNullOrWhiteSpace(eventName))
+        {
+            return false;
+        }
+
+        var normalizedEventName = eventName.Replace("/", string.Empty, StringComparison.Ordinal)
+            .Replace("_", string.Empty, StringComparison.Ordinal)
+            .Replace("-", string.Empty, StringComparison.Ordinal);
+
+        return normalizedEventName.Contains("turn", StringComparison.OrdinalIgnoreCase) &&
+               (normalizedEventName.Contains("completed", StringComparison.OrdinalIgnoreCase) ||
+                normalizedEventName.Contains("failed", StringComparison.OrdinalIgnoreCase) ||
+                normalizedEventName.Contains("cancelled", StringComparison.OrdinalIgnoreCase) ||
+                normalizedEventName.Contains("canceled", StringComparison.OrdinalIgnoreCase));
     }
 
     private static bool TryExtractRateLimitsJson(JsonElement root, out string? rateLimitsJson)
@@ -1227,7 +1257,7 @@ public sealed partial class CodexAgentRunner(
             return false;
         }
 
-        usage = new UsageSnapshot(inputTokens, outputTokens, totalTokens);
+        usage = new UsageSnapshot(inputTokens, outputTokens, totalTokens, IsDelta: false);
         return true;
     }
 
@@ -1663,5 +1693,5 @@ public sealed partial class CodexAgentRunner(
 
     private sealed record ToolCallRequest(object RequestId, string Name, string? InputJson);
 
-    private sealed record UsageSnapshot(int? InputTokens, int? OutputTokens, int? TotalTokens);
+    private sealed record UsageSnapshot(int? InputTokens, int? OutputTokens, int? TotalTokens, bool IsDelta);
 }

--- a/src/Symphony.Infrastructure.Persistence.Sqlite/Symphony.Infrastructure.Persistence.Sqlite.csproj
+++ b/src/Symphony.Infrastructure.Persistence.Sqlite/Symphony.Infrastructure.Persistence.Sqlite.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.0" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.8" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/Symphony.Infrastructure.Workflows/Symphony.Infrastructure.Workflows.csproj
+++ b/src/Symphony.Infrastructure.Workflows/Symphony.Infrastructure.Workflows.csproj
@@ -9,7 +9,7 @@
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.0" />
-    <PackageReference Include="Scriban" Version="7.0.6" />
+    <PackageReference Include="Scriban" Version="7.2.2" />
     <PackageReference Include="YamlDotNet" Version="16.3.0" />
   </ItemGroup>
 

--- a/tests/Symphony.Integration.Tests/CodexAgentRunnerTests.cs
+++ b/tests/Symphony.Integration.Tests/CodexAgentRunnerTests.cs
@@ -136,7 +136,7 @@ public sealed class CodexAgentRunnerTests
     {
         var update = CreateProtocolUpdate("""
             {
-              "method": "turn/completed",
+              "method": "notification",
               "params": {
                 "message": "done",
                 "usage": {
@@ -151,6 +151,29 @@ public sealed class CodexAgentRunnerTests
         Assert.Null(update.InputTokens);
         Assert.Null(update.OutputTokens);
         Assert.Null(update.TotalTokens);
+    }
+
+    [Fact]
+    public void CreateProtocolUpdate_ShouldReadDeltaUsageFromTurnCompletedPayloads()
+    {
+        var update = CreateProtocolUpdate("""
+            {
+              "method": "turn/completed",
+              "params": {
+                "message": "done",
+                "usage": {
+                  "input_tokens": 11,
+                  "output_tokens": 7,
+                  "total_tokens": 18
+                }
+              }
+            }
+            """);
+
+        Assert.Equal(11, update.InputTokens);
+        Assert.Equal(7, update.OutputTokens);
+        Assert.Equal(18, update.TotalTokens);
+        Assert.True(update.TokenUsageIsDelta);
     }
 
     [Fact]

--- a/tests/Symphony.Integration.Tests/CodexCliPreflightEvaluatorTests.cs
+++ b/tests/Symphony.Integration.Tests/CodexCliPreflightEvaluatorTests.cs
@@ -16,8 +16,8 @@ public sealed class CodexCliPreflightEvaluatorTests
             var result = await CodexCliPreflightEvaluator.CheckAsync(
                 CreateRunner(new Dictionary<string, CodexCliCommandResult>(StringComparer.Ordinal)
                 {
-                    ["codex --version"] = new(0, "codex-cli 0.114.0", string.Empty),
-                    ["npm view @openai/codex version"] = new(0, "0.114.0", string.Empty),
+                    ["codex --version"] = new(0, "codex-cli 0.135.0", string.Empty),
+                    ["npm view @openai/codex version"] = new(0, "0.135.0", string.Empty),
                     ["codex login status"] = new(0, "Logged in using ChatGPT", string.Empty)
                 }),
                 codexHome,
@@ -25,8 +25,8 @@ public sealed class CodexCliPreflightEvaluatorTests
                 CancellationToken.None);
 
             Assert.True(result.IsReadyToStart);
-            Assert.Equal("0.114.0", result.InstalledVersion);
-            Assert.Equal("0.114.0", result.LatestVersion);
+            Assert.Equal("0.135.0", result.InstalledVersion);
+            Assert.Equal("0.135.0", result.LatestVersion);
             Assert.True(result.LatestVersionVerified);
             Assert.True(result.HasAuthJson);
             Assert.True(result.LoginConfigured);
@@ -50,7 +50,7 @@ public sealed class CodexCliPreflightEvaluatorTests
                 CreateRunner(new Dictionary<string, CodexCliCommandResult>(StringComparer.Ordinal)
                 {
                     ["codex --version"] = new(0, "codex-cli 0.113.0", string.Empty),
-                    ["npm view @openai/codex version"] = new(0, "0.114.0", string.Empty),
+                    ["npm view @openai/codex version"] = new(0, "0.135.0", string.Empty),
                     ["codex login status"] = new(0, "Logged in using ChatGPT", string.Empty)
                 }),
                 codexHome,
@@ -60,7 +60,7 @@ public sealed class CodexCliPreflightEvaluatorTests
             Assert.False(result.IsReadyToStart);
             Assert.Contains(
                 result.BlockingIssues,
-                issue => issue.Contains("Symphony-validated version 0.114.0", StringComparison.Ordinal));
+                issue => issue.Contains("Symphony-validated version 0.135.0", StringComparison.Ordinal));
         }
         finally
         {
@@ -78,8 +78,8 @@ public sealed class CodexCliPreflightEvaluatorTests
             var result = await CodexCliPreflightEvaluator.CheckAsync(
                 CreateRunner(new Dictionary<string, CodexCliCommandResult>(StringComparer.Ordinal)
                 {
-                    ["codex --version"] = new(0, "codex-cli 0.114.0", string.Empty),
-                    ["npm view @openai/codex version"] = new(0, "0.114.0", string.Empty),
+                    ["codex --version"] = new(0, "codex-cli 0.135.0", string.Empty),
+                    ["npm view @openai/codex version"] = new(0, "0.135.0", string.Empty),
                     ["codex login status"] = new(0, "Logged in using ChatGPT", string.Empty)
                 }),
                 codexHome,
@@ -109,14 +109,14 @@ public sealed class CodexCliPreflightEvaluatorTests
                 Path.Combine(codexHome, "version.json"),
                 """
                 {
-                  "latest_version": "0.114.0"
+                  "latest_version": "0.135.0"
                 }
                 """);
 
             var result = await CodexCliPreflightEvaluator.CheckAsync(
                 CreateRunner(new Dictionary<string, CodexCliCommandResult>(StringComparer.Ordinal)
                 {
-                    ["codex --version"] = new(0, "codex-cli 0.114.0", string.Empty),
+                    ["codex --version"] = new(0, "codex-cli 0.135.0", string.Empty),
                     ["npm view @openai/codex version"] = new(1, string.Empty, "npm unavailable"),
                     ["codex login status"] = new(0, "Logged in using ChatGPT", string.Empty)
                 }),
@@ -163,7 +163,7 @@ public sealed class CodexCliPreflightEvaluatorTests
                 Path.Combine(codexHome, "version.json"),
                 """
                 {
-                  "latest_version": "0.114.0"
+                  "latest_version": "0.135.0"
                 }
                 """);
 
@@ -172,7 +172,7 @@ public sealed class CodexCliPreflightEvaluatorTests
                     ? WaitForCancellationAsync(token)
                     : Task.FromResult(command switch
                     {
-                        "codex --version" => new CodexCliCommandResult(0, "codex-cli 0.114.0", string.Empty),
+                        "codex --version" => new CodexCliCommandResult(0, "codex-cli 0.135.0", string.Empty),
                         "codex login status" => new CodexCliCommandResult(0, "Logged in using ChatGPT", string.Empty),
                         _ => throw new InvalidOperationException($"Unexpected command '{command}'.")
                     }),

--- a/tests/Symphony.Integration.Tests/InstallCommandTests.cs
+++ b/tests/Symphony.Integration.Tests/InstallCommandTests.cs
@@ -253,9 +253,9 @@ public sealed class InstallCommandTests
     {
         return readyToStart
             ? new CodexCliPreflightResult(
-                InstalledVersion: "0.114.0",
-                ValidatedVersion: "0.114.0",
-                LatestVersion: "0.114.0",
+                InstalledVersion: "0.135.0",
+                ValidatedVersion: "0.135.0",
+                LatestVersion: "0.135.0",
                 LatestVersionSource: "npm",
                 LatestVersionVerified: true,
                 AuthJsonPath: Path.Combine(Path.GetTempPath(), ".codex", "auth.json"),
@@ -266,8 +266,8 @@ public sealed class InstallCommandTests
                 RemediationSteps: [])
             : new CodexCliPreflightResult(
                 InstalledVersion: "0.113.0",
-                ValidatedVersion: "0.114.0",
-                LatestVersion: "0.114.0",
+                ValidatedVersion: "0.135.0",
+                LatestVersion: "0.135.0",
                 LatestVersionSource: "npm",
                 LatestVersionVerified: true,
                 AuthJsonPath: Path.Combine(Path.GetTempPath(), ".codex", "auth.json"),
@@ -275,13 +275,13 @@ public sealed class InstallCommandTests
                 LoginConfigured: false,
                 BlockingIssues:
                 [
-                    "Codex CLI 0.113.0 is older than the Symphony-validated version 0.114.0.",
+                    "Codex CLI 0.113.0 is older than the Symphony-validated version 0.135.0.",
                     $"Codex auth file is missing: '{Path.Combine(Path.GetTempPath(), ".codex", "auth.json")}'."
                 ],
                 Warnings: [],
                 RemediationSteps:
                 [
-                    "Update Codex CLI with `npm install -g @openai/codex@0.114.0`.",
+                    "Update Codex CLI with `npm install -g @openai/codex@0.135.0`.",
                     "Run `codex login` in another terminal, finish the sign-in flow, then return here."
                 ]);
     }

--- a/tests/Symphony.Integration.Tests/IssueExecutionCoordinatorTests.cs
+++ b/tests/Symphony.Integration.Tests/IssueExecutionCoordinatorTests.cs
@@ -1,0 +1,55 @@
+using System.Reflection;
+using Symphony.Core.Models;
+using Symphony.Host.Services;
+using Symphony.Infrastructure.Persistence.Sqlite.Entities;
+
+namespace Symphony.Integration.Tests;
+
+public sealed class IssueExecutionCoordinatorTests
+{
+    [Fact]
+    public void ApplyTokenTotals_ShouldAccumulateTurnUsageDeltasAndReconcileAbsoluteSnapshots()
+    {
+        var run = new RunEntity();
+        var applyTokenTotals = typeof(IssueExecutionCoordinator)
+            .GetMethods(BindingFlags.NonPublic | BindingFlags.Static)
+            .Single(method =>
+            {
+                if (method.Name != "ApplyTokenTotals")
+                {
+                    return false;
+                }
+
+                var parameters = method.GetParameters();
+                return parameters.Length == 2 &&
+                       parameters[0].ParameterType == typeof(RunEntity) &&
+                       parameters[1].ParameterType == typeof(AgentRunUpdate);
+            });
+
+        applyTokenTotals.Invoke(null, [run, CreateTokenUpdate(10, 4, 14, tokenUsageIsDelta: true)]);
+        applyTokenTotals.Invoke(null, [run, CreateTokenUpdate(10, 4, 14, tokenUsageIsDelta: true)]);
+        applyTokenTotals.Invoke(null, [run, CreateTokenUpdate(30, 12, 42, tokenUsageIsDelta: false)]);
+
+        Assert.Equal(30, run.InputTokens);
+        Assert.Equal(12, run.OutputTokens);
+        Assert.Equal(42, run.TotalTokens);
+        Assert.Equal(30, run.LastReportedInputTokens);
+        Assert.Equal(12, run.LastReportedOutputTokens);
+        Assert.Equal(42, run.LastReportedTotalTokens);
+    }
+
+    private static AgentRunUpdate CreateTokenUpdate(
+        int inputTokens,
+        int outputTokens,
+        int totalTokens,
+        bool tokenUsageIsDelta)
+    {
+        return new AgentRunUpdate(
+            EventType: "turn/completed",
+            Timestamp: DateTimeOffset.UtcNow,
+            InputTokens: inputTokens,
+            OutputTokens: outputTokens,
+            TotalTokens: totalTokens,
+            TokenUsageIsDelta: tokenUsageIsDelta);
+    }
+}


### PR DESCRIPTION
## Summary

This PR updates Symphony's Codex integration and dependency baseline.

It bumps the validated and container-installed Codex CLI version from `0.114.0` to `0.135.0`, updates the installer preflight expectations and tests, fixes token usage accounting for current Codex app-server events, and removes the NuGet vulnerability warnings that were showing during restore/build.

## Root Cause and Fix

The dashboard was showing `0` tokens because Symphony only counted absolute token usage snapshots such as `thread/tokenUsage/updated` and intentionally ignored generic `usage` payloads on ordinary events. Current Codex app-server behavior can emit per-turn usage on terminal turn events such as `turn/completed`, so no persisted run/session counters moved when those absolute snapshots were absent.

The fix adds a `TokenUsageIsDelta` marker to `AgentRunUpdate`, treats usage on turn terminal events as per-turn deltas, and keeps existing absolute snapshot handling for `thread/tokenUsage/updated` and `totalTokenUsage`. The persistence layer now accumulates deltas while still reconciling later absolute snapshots without double-counting.

## Dependency Updates

`Scriban` was updated from `7.0.6` to `7.2.2`. `System.Security.Cryptography.Xml` was added explicitly at `10.0.8` in the SQLite persistence project to override the vulnerable transitive `9.0.0` version.

## Validation

- `npm view @openai/codex version` returned `0.135.0`
- `dotnet list package --vulnerable --include-transitive` reports no vulnerable packages
- `dotnet build` succeeds with `0 Warning(s), 0 Error(s)`
- `dotnet test` passes with `134` passed, `1` skipped, `0` failed
